### PR TITLE
Add dotted integer index

### DIFF
--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -17,7 +17,9 @@ reserved = _{
 //
 
 // Allow leading 0 - "0001" => 1
-integer = @{ "-" ? ~ ASCII_DIGIT +}
+integer = @{ "-" ? ~ ASCII_DIGIT + }
+
+positive_integer = @{ ASCII_DIGIT + }
 
 // Allow leading 0 - "000.1" => 0.1
 float = @{ "-" ? ~ ASCII_DIGIT + ~ "." ~ ASCII_DIGIT + }
@@ -48,7 +50,7 @@ square_brackets = _{
 }
 
 dotted_square_bracket_identifier = ${
-    identifier ~ ( ("." ~ identifier) | square_brackets )*
+    identifier ~ ( ("." ~ ( identifier | positive_integer ) ) | square_brackets )*
 }
 
 string_concat = { (string | dotted_square_bracket_identifier) ~ ("~" ~ (float | integer | string | dotted_square_bracket_identifier))+ }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -253,7 +253,7 @@ fn remove_string_quotes(input: &str) -> Result<String> {
 // }
 //
 // dotted_square_bracket_identifier = ${
-//     identifier ~ ( ("." ~ identifier) | square_brackets )*
+//     identifier ~ ( ("." ~ ( identifier | positive_integer ) ) | square_brackets )*
 // }
 //
 fn parse_dotted_square_bracket_identifier_value(pair: Pair<Rule>) -> Result<Identifier> {
@@ -263,7 +263,7 @@ fn parse_dotted_square_bracket_identifier_value(pair: Pair<Rule>) -> Result<Iden
         let value = match p.as_rule() {
             Rule::identifier => IdentifierValue::Name(p.as_str().to_string()),
             Rule::string => IdentifierValue::StringIndex(remove_string_quotes(p.as_str())?),
-            Rule::integer => IdentifierValue::IntegerIndex(p.as_str().parse()?),
+            Rule::integer | Rule::positive_integer => IdentifierValue::IntegerIndex(p.as_str().parse()?),
             Rule::dotted_square_bracket_identifier => {
                 IdentifierValue::IdentifierIndex(parse_dotted_square_bracket_identifier_value(p)?)
             }

--- a/tests/engine/eval/lookup.rs
+++ b/tests/engine/eval/lookup.rs
@@ -69,6 +69,48 @@ fn test_dotted() {
 }
 
 #[test]
+fn test_dotted_integer_index() {
+    let ctx = Context::new(json!({
+        "root": [
+            "hallo",
+            10,
+            3.2,
+            true,
+            ["a", "b"],
+            {"a": "b"},
+            null
+        ]}));
+
+    test_eval_eq!("root.0", ctx, json!("hallo"));
+    test_eval_eq!("root.1", ctx, json!(10));
+    test_eval_eq!("root.2", ctx, json!(3.2));
+    test_eval_eq!("root.3", ctx, json!(true));
+    test_eval_eq!("root.4", ctx, json!(["a", "b"]));
+    test_eval_eq!("root.5", ctx, json!({"a": "b"}));
+    test_eval_eq!("root.6", ctx, json!(null));
+
+    test_eval_err!("root.7", ctx);
+}
+
+#[test]
+fn test_dotted_integer_index_mixed() {
+    let ctx = Context::new(json!({
+        "people": [
+            {
+                "name": "Robert"
+            },
+            {
+                "name": "Cyryl"
+            }
+        ]}));
+
+    test_eval_eq!("people.0[`name`]", ctx, json!("Robert"));
+    test_eval_eq!("people.0.name", ctx, json!("Robert"));
+    test_eval_eq!("people.1[`name`]", ctx, json!("Cyryl"));
+    test_eval_eq!("people.1.name", ctx, json!("Cyryl"));
+}
+
+#[test]
 fn test_square_bracket_string() {
     let ctx = Context::new(json!({
         "root": {


### PR DESCRIPTION
It’s possible to use `array[1]` or `array.1` according to specification. The second possibility wasn’t implemeneted and is added by this PR.