### PR TITLE
Replace error chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,3 @@ install:
 
 script:
   - ci/test.sh
-
-notifications:
-  email:
-    - robert@balena.io
-    - cyryl@balena.io
-  on_success: change
-  on_failure: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ travis-ci = { repository = "balena-io-modules/balena-temen", branch = "master" }
 [dependencies]
 approx = "0.3"
 chrono = "0.4"
-error-chain = "0.12"
 lazy_static = "1"
 pest = "2"
 pest_derive = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "balena-temen"
 version = "0.0.9"
-authors = ["Robert Vojta <robert@balena.io>"]
+authors = ["Robert Vojta <robert@balena.io>", "Cyryl Płotnicki <cyryl@balena.io>"]
 edition = "2018"
 maintenance = { status = "actively-developed" }
 license = "Apache-2.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -25,7 +25,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use crate::{
-    error::{bail, Error},
+    error::*,
     parser::parse
 };
 
@@ -365,10 +365,11 @@ impl Expression {
     /// Converts self into [`Identifier`]
     ///
     /// [`Identifier`]: struct.Identifier.html
-    pub fn into_identifier(self) -> Result<Identifier, Error> {
+    pub fn into_identifier(self) -> Result<Identifier> {
         match self.value {
             ExpressionValue::Identifier(identifier) => Ok(identifier),
-            _ => bail!("expression is not an identifier"),
+            _ => Err(Error::with_message("expression does not contain an identifier")
+                .context("expression", format!("{:?}", self))),
         }
     }
 }
@@ -376,7 +377,7 @@ impl Expression {
 impl FromStr for Expression {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Expression, Self::Err> {
+    fn from_str(s: &str) -> Result<Expression> {
         parse(s)
     }
 }

--- a/src/builtin/filter/datetime.rs
+++ b/src/builtin/filter/datetime.rs
@@ -4,17 +4,29 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use serde_json::Value;
 
 use crate::context::Context;
-use crate::error::Result;
+use crate::error::*;
 
-fn format_timestamp(filter: &str, input: &Value, args: &HashMap<String, Value>, default: &str) -> Result<Value> {
-    let ts = input
-        .as_i64()
-        .ok_or_else(|| format!("`{}` accepts integer only", filter))?;
+fn format_timestamp(
+    filter: &'static str,
+    input: &Value,
+    args: &HashMap<String, Value>,
+    default: &str,
+) -> Result<Value> {
+    let ts = input.as_i64().ok_or_else(|| {
+        Error::with_message("invalid input type")
+            .context("filter", filter)
+            .context("expected", "i64")
+            .context("input", input.to_string())
+    })?;
 
     let format = match args.get("format") {
-        Some(x) => x
-            .as_str()
-            .ok_or_else(|| format!("`{}` format must be a string", filter))?,
+        Some(x) => x.as_str().ok_or_else(|| {
+            Error::with_message("invalid argument type")
+                .context("filter", filter)
+                .context("argument name", "format")
+                .context("argument value", x.to_string())
+                .context("expected", "string")
+        })?,
         None => default,
     };
 

--- a/src/builtin/filter/lower.rs
+++ b/src/builtin/filter/lower.rs
@@ -3,10 +3,15 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use crate::context::Context;
-use crate::error::Result;
+use crate::error::*;
 
 pub(crate) fn lower(input: &Value, _args: &HashMap<String, Value>, _context: &mut Context) -> Result<Value> {
-    let s = input.as_str().ok_or_else(|| "`lower` filter accepts string only")?;
+    let s = input.as_str().ok_or_else(|| {
+        Error::with_message("invalid input type")
+            .context("filter", "lower")
+            .context("expected", "string")
+            .context("input", input.to_string())
+    })?;
     Ok(Value::String(s.to_lowercase()))
 }
 

--- a/src/builtin/filter/trim.rs
+++ b/src/builtin/filter/trim.rs
@@ -3,16 +3,17 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use crate::context::Context;
-use crate::error::Result;
+use crate::error::*;
 
 pub(crate) fn trim(input: &Value, _args: &HashMap<String, Value>, _context: &mut Context) -> Result<Value> {
-    Ok(Value::String(
-        input
-            .as_str()
-            .ok_or_else(|| "`trim` filter accepts string only")?
-            .trim()
-            .to_string(),
-    ))
+    let s = input.as_str().ok_or_else(|| {
+        Error::with_message("invalid input type")
+            .context("filter", "trim")
+            .context("expected", "string")
+            .context("input", input.to_string())
+    })?;
+
+    Ok(Value::String(s.trim().to_string()))
 }
 
 #[cfg(test)]

--- a/src/builtin/filter/upper.rs
+++ b/src/builtin/filter/upper.rs
@@ -3,10 +3,15 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use crate::context::Context;
-use crate::error::Result;
+use crate::error::*;
 
 pub(crate) fn upper(input: &Value, _args: &HashMap<String, Value>, _context: &mut Context) -> Result<Value> {
-    let s = input.as_str().ok_or_else(|| "`upper` filter accepts string only")?;
+    let s = input.as_str().ok_or_else(|| {
+        Error::with_message("invalid input type")
+            .context("filter", "trim")
+            .context("expected", "string")
+            .context("input", input.to_string())
+    })?;
     Ok(Value::String(s.to_uppercase()))
 }
 

--- a/src/builtin/function/now.rs
+++ b/src/builtin/function/now.rs
@@ -4,20 +4,28 @@ use chrono::{DateTime, Local, Utc};
 use serde_json::{Number, Value};
 
 use crate::context::Context;
-use crate::error::Result;
+use crate::error::*;
 
 fn now_with_cached(cached: DateTime<Utc>, args: &HashMap<String, Value>) -> Result<Value> {
-    let timestamp = args
-        .get("timestamp")
-        .unwrap_or_else(|| &Value::Bool(false))
-        .as_bool()
-        .ok_or_else(|| "timestamp must be a boolean value")?;
+    let timestamp = args.get("timestamp").unwrap_or_else(|| &Value::Bool(false));
 
-    let utc = args
-        .get("utc")
-        .unwrap_or_else(|| &Value::Bool(false))
-        .as_bool()
-        .ok_or_else(|| "utc must be a boolean value")?;
+    let timestamp = timestamp.as_bool().ok_or_else(|| {
+        Error::with_message("invalid argument type")
+            .context("function", "now")
+            .context("argument name", "timestamp")
+            .context("argument value", timestamp.to_string())
+            .context("expected", "boolean")
+    })?;
+
+    let utc = args.get("utc").unwrap_or_else(|| &Value::Bool(false));
+
+    let utc = utc.as_bool().ok_or_else(|| {
+        Error::with_message("invalid argument type")
+            .context("function", "now")
+            .context("argument name", "utc")
+            .context("argument value", utc.to_string())
+            .context("expected", "boolean")
+    })?;
 
     match (utc, timestamp) {
         (true, true) => Ok(Value::Number(Number::from(cached.timestamp()))),

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,9 @@ impl<T> ResultExt<T> for Result<T> {
 
 /// Error type
 pub struct Error {
+    // Box is not really required here, but we'd like to keep
+    // Result as small as possible. Inner can be very huge
+    // sometimes.
     inner: Box<Inner>,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@
 //! fn eval_math() -> Result<()> {
 //!     Ok(eval_as_number()
 //!         .frame_with(|| "eval_math".into())
-//!         .context_with(|| ("rhs".into(), "`23`".into()))?)
+//!         .context_with(|| ("rhs".to_string(), "`23`".to_string()))?)
 //! }
 //!
 //! fn eval() -> Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,125 @@
-//! Error chain
-use error_chain::*;
-pub(crate) use error_chain::bail;
+//! Error handling
+use std::borrow::Cow;
+use std::error;
+use std::fmt;
+use std::result;
 
-use crate::parser::Rule;
+/// Standard library result wrapper
+pub type Result<T> = result::Result<T, Error>;
 
-error_chain! {
-    errors {}
+/// Context key type
+pub type Key = Cow<'static, str>;
+/// Context value type
+pub type Value = Cow<'static, str>;
 
-    foreign_links {
-        Json(serde_json::Error) #[doc = "JSON (de)serialization error"];
-        Pest(pest::error::Error<Rule>) #[doc = "Parser error"];
-        ParseIntError(std::num::ParseIntError) #[doc = "Integer parser error"];
-        ParseFloatError(std::num::ParseFloatError) #[doc = "Float parser error"];
+/// Result extension
+pub trait ResultExt<T> {
+    /// Appends key, value pair to the context
+    ///
+    /// # Arguments
+    ///
+    /// * `k` - A key
+    /// * `v` - A value
+    fn context<K, V>(self, k: K, v: V) -> Result<T>
+    where
+        K: Into<Key>,
+        V: Into<Value>;
+}
+
+impl<T> ResultExt<T> for Result<T> {
+    fn context<K, V>(self, k: K, v: V) -> Result<T>
+    where
+        K: Into<Key>,
+        V: Into<Value>,
+    {
+        self.map_err(|e| e.context(k, v))
+    }
+}
+
+/// Error type
+pub struct Error {
+    inner: Box<Inner>,
+}
+
+impl Error {
+    /// Creates new error with message
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - An error message
+    pub fn with_message(message: &'static str) -> Error {
+        let inner = Inner::new(message);
+        Error { inner: Box::new(inner) }
+    }
+
+    /// Adds key, value pair to the error's context
+    ///
+    /// # Arguments
+    ///
+    /// * `k` - A key
+    /// * `v` - A value
+    pub fn context<K, V>(mut self, k: K, v: V) -> Error
+    where
+        K: Into<Key>,
+        V: Into<Value>,
+    {
+        self.inner.push(k, v);
+        self
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "temen: {}", self.inner.message)?;
+        if !self.inner.context.is_empty() {
+            writeln!(f, "└ context:")?;
+            let last_index = self.inner.context().len() - 1;
+            for (idx, (k, v)) in self.inner.context().iter().enumerate() {
+                if idx == last_index {
+                    writeln!(f, "   └ {} = {}", k, v)?;
+                } else {
+                    writeln!(f, "   ├ {} = {}", k, v)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(error::Error + 'static)> {
+        None
+    }
+}
+
+struct Inner {
+    message: &'static str,
+    context: Vec<(Key, Value)>,
+}
+
+impl Inner {
+    fn new(message: &'static str) -> Inner {
+        Inner {
+            message,
+            context: vec![],
+        }
+    }
+
+    fn push<K, V>(&mut self, k: K, v: V)
+    where
+        K: Into<Key>,
+        V: Into<Value>,
+    {
+        self.context.push((k.into(), v.into()))
+    }
+
+    fn context(&self) -> &[(Key, Value)] {
+        self.context.as_ref()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,13 +72,13 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "temen: {}", self.inner.message)?;
         if !self.inner.context.is_empty() {
-            writeln!(f, "└ context:")?;
+            writeln!(f, " └ context:")?;
             let last_index = self.inner.context().len() - 1;
             for (idx, (k, v)) in self.inner.context().iter().enumerate() {
                 if idx == last_index {
-                    writeln!(f, "   └ {} = {}", k, v)?;
+                    writeln!(f, "    └ {} = {}", k, v)?;
                 } else {
-                    writeln!(f, "   ├ {} = {}", k, v)?;
+                    writeln!(f, "    ├ {} = {}", k, v)?;
                 }
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,37 @@
 //! Error handling
+//!
+//! A module allowing us to create more detailed, context aware, errors.
+//!
+//! # Examples
+//!
+//! Invalid UTC argument type:
+//!
+//! ```rust
+//! use balena_temen::{
+//!     ast::Identifier,
+//!     Engine, Context, Value,
+//!     error::*
+//! };
+//! use std::collections::HashMap;
+//!
+//! let engine: Engine = Engine::default();
+//! let mut ctx = Context::default();
+//! let position = Identifier::default();
+//! let data = Value::Null;
+//!
+//! eprintln!("{}", engine.eval("now(utc=`yes`)", &position, &data, &mut ctx).err().unwrap());
+//! ```
+//!
+//! Printed error:
+//!
+//! ```text
+//! temen: invalid argument type
+//!  └ context:
+//!     ├ function = now
+//!     ├ argument name = utc
+//!     ├ argument value = "yes"
+//!     └ expected = boolean
+//! ```
 use std::borrow::Cow;
 use std::error;
 use std::fmt;

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,14 +34,14 @@
 //! temen: unable to evaluate as a number
 //!  ├ frame[0]
 //!  |  └ context:
-//!  |     ├ value = some value
-//!  |     └ expected = number
+//!  |     ├ value: some value
+//!  |     └ expected: number
 //!  ├ frame[1]: eval_math
 //!  |  └ context:
-//!  |     └ rhs = `23`
+//!  |     └ rhs: `23`
 //!  └ frame[2]: eval
 //!     └ context:
-//!        └ expression = 1 = `23`
+//!        └ expression: 1 = `23`
 //! ```
 use std::borrow::Cow;
 use std::error;
@@ -235,9 +235,9 @@ impl fmt::Display for Error {
                 let last_index = frame.context().len() - 1;
                 for (idx, (k, v)) in frame.context().iter().enumerate() {
                     if idx == last_index {
-                        writeln!(f, "{}    └ {} = {}", context_indent, k, v)?;
+                        writeln!(f, "{}    └ {}: {}", context_indent, k, v)?;
                     } else {
-                        writeln!(f, "{}    ├ {} = {}", context_indent, k, v)?;
+                        writeln!(f, "{}    ├ {}: {}", context_indent, k, v)?;
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,6 @@
 //! ```
 //!
 //! Visit [ast] module documentation for more info.
-
 //!
 //! [balena]: https://www.balena.io
 //! [ast]: ast/index.html

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@
 use approx::Relative;
 use serde_json::Number;
 
-use crate::error::{bail, Result};
+use crate::error::*;
 
 /// Check that the float is not infinite or NaN
 ///
@@ -14,11 +14,11 @@ use crate::error::{bail, Result};
 /// * `number` - A number to check
 pub fn validate_f64(number: f64) -> Result<f64> {
     if number.is_nan() {
-        bail!("parse_f64: NaN not supported");
+        return Err(Error::with_message("NaN f64 not supported"));
     }
 
     if number.is_infinite() {
-        bail!("parse_f64: infinite not supported");
+        return Err(Error::with_message("infinite f64 not supported"));
     }
 
     Ok(number)

--- a/tests/engine/eval/concat.rs
+++ b/tests/engine/eval/concat.rs
@@ -1,4 +1,5 @@
 use serde_json::json;
+
 use crate::test_eval_eq;
 
 #[test]

--- a/tests/engine/eval/filter.rs
+++ b/tests/engine/eval/filter.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
 use serde_json::json;
-use crate::{test_eval_eq, test_eval_err};
 
-use balena_temen::{Context, Engine, EngineBuilder, Value};
+use balena_temen::{Context, Engine, EngineBuilder, error::*, Value};
+
+use crate::{test_eval_eq, test_eval_err};
 
 #[test]
 fn default_filters_are_registered() {
@@ -34,7 +35,7 @@ fn custom_filter() {
         if input.is_string() {
             Ok(Value::String(input.as_str().unwrap().replace("a", "b")))
         } else {
-            Err("no string, no fun".into())
+            Err(Error::with_message("no string, no fun"))
         }
     };
 

--- a/tests/engine/eval/function.rs
+++ b/tests/engine/eval/function.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
 use serde_json::json;
-use crate::{test_eval_eq, test_eval_err, test_eval_ok};
 
 use balena_temen::{Context, Engine, EngineBuilder, Value};
+
+use crate::{test_eval_eq, test_eval_err, test_eval_ok};
 
 #[test]
 fn default_functions_are_registered() {

--- a/tests/engine/eval/logical.rs
+++ b/tests/engine/eval/logical.rs
@@ -1,4 +1,5 @@
 use serde_json::json;
+
 use crate::test_eval_eq;
 
 #[test]

--- a/tests/engine/eval/math.rs
+++ b/tests/engine/eval/math.rs
@@ -1,4 +1,5 @@
 use serde_json::json;
+
 use crate::{test_eval_eq, test_eval_err};
 
 // TODO Add better comparison of numbers, especially floats

--- a/tests/parser/filter.rs
+++ b/tests/parser/filter.rs
@@ -1,4 +1,5 @@
 use balena_temen::{error::Error, parser::ast::*};
+
 use crate::test_parse_eq;
 
 #[test]

--- a/tests/parser/function.rs
+++ b/tests/parser/function.rs
@@ -1,4 +1,5 @@
 use balena_temen::ast::*;
+
 use crate::{fn_args_map, test_parse_eq};
 
 #[test]

--- a/tests/parser/identifier.rs
+++ b/tests/parser/identifier.rs
@@ -1,4 +1,5 @@
 use balena_temen::ast::*;
+
 use crate::{test_parse_eq, test_parse_err};
 
 #[test]

--- a/tests/parser/logical.rs
+++ b/tests/parser/logical.rs
@@ -1,4 +1,5 @@
 use balena_temen::ast::*;
+
 use crate::{test_parse_eq, test_parse_err};
 
 #[test]

--- a/tests/parser/math.rs
+++ b/tests/parser/math.rs
@@ -1,4 +1,5 @@
 use balena_temen::ast::*;
+
 use crate::{test_parse_eq, test_parse_err};
 
 #[test]

--- a/tests/parser/primitive.rs
+++ b/tests/parser/primitive.rs
@@ -1,4 +1,5 @@
 use balena_temen::ast::*;
+
 use crate::{test_parse_eq, test_parse_err};
 
 macro_rules! exp {

--- a/tests/parser/relational.rs
+++ b/tests/parser/relational.rs
@@ -1,4 +1,5 @@
 use balena_temen::ast::*;
+
 use crate::{test_parse_eq, test_parse_err};
 
 #[test]


### PR DESCRIPTION
Fixes #24 

PR contains:

* removed explicit notifications from `.travis.yml`
* added @cyplo as an author
* replaced error-chain with custom error type [1]
* integrations tests imports organized

[1] This is ongoing work, because I'd like to add more info to error messages (like the whole expression, etc.), but it's kinda okay for now. It's nothing that should block us - internal stuff, no public API breakage.

Why custom error and not failure for example? error-chain was deprecated and failure recommended. The problem here is that even the failure is not magic & final solution, there's still some ongoing work, ... Also I think that we should use custom error types for libs, which do comply with `std::error::Error`. The reason I was using error-chain was simple - speed & experimentation. Now, when things are settling down, there's no reason to use it.
