### PR TITLE
Simplify identifier values

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -175,7 +175,7 @@ impl StringConcat {
 ///   |      │   |
 ///   |      |   └ IdentifierValue::Name("name")
 ///   |      |
-///   |      └ IdentifierValue::IntegerIndex(0)
+///   |      └ IdentifierValue::Index(0)
 ///   |
 ///   └ IdentifierValue::Name("networks")
 /// ```
@@ -183,15 +183,15 @@ impl StringConcat {
 /// ```text
 /// persons[boss.id]["name"]
 ///   |      │         |
-///   |      |         └ IdentifierValue::StringIndex("name")
+///   |      |         └ IdentifierValue::Name("name")
 ///   |      |
-///   |      └ IdentifierValue::IdentifierIndex(boss.id)
-///   |                                          |   |
-///   |                                          |   └ IdentifierValue::Name("id")
-///   |                                          |
-///   |                                          └ IdentifierValue::Name("boss")
+///   |      └ IdentifierValue::Identifier(boss.id)
+///   |                                     |   |
+///   |                                     |   └ IdentifierValue::Name("id")
+///   |                                     |
+///   |                                     └ IdentifierValue::Name("boss")
 ///   |
-///   └ IdentifierValue::Name(String)
+///   └ IdentifierValue::Name("persons")
 /// ```
 ///
 /// ```text
@@ -250,14 +250,12 @@ impl Default for Identifier {
 /// An identifier value (component)
 #[derive(Clone, Debug, PartialEq)]
 pub enum IdentifierValue {
-    /// A name (variable/property name)
+    /// A string index (dictionaries)
     Name(String),
     /// An integer index (arrays)
-    IntegerIndex(isize),
-    /// A string index (dictionaries)
-    StringIndex(String),
+    Index(isize),
     /// An indirect index (value of another identifier)
-    IdentifierIndex(Identifier),
+    Identifier(Identifier),
     /// Current object
     This,
     /// Parent object

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -271,14 +271,14 @@ fn parse_dotted_square_bracket_identifier_value(pair: Pair<Rule>) -> Result<Iden
                 "super" => IdentifierValue::Super,
                 _ => IdentifierValue::Name(p.as_str().to_string()),
             },
-            Rule::string => IdentifierValue::StringIndex(remove_string_quotes(p.as_str())?),
-            Rule::integer | Rule::positive_integer => IdentifierValue::IntegerIndex(
+            Rule::string => IdentifierValue::Name(remove_string_quotes(p.as_str())?),
+            Rule::integer | Rule::positive_integer => IdentifierValue::Index(
                 p.as_str()
                     .parse()
                     .map_err(|_| Error::with_message("unable to parse i64").context("value", p.to_string()))?,
             ),
             Rule::dotted_square_bracket_identifier => {
-                IdentifierValue::IdentifierIndex(parse_dotted_square_bracket_identifier_value(p)?)
+                IdentifierValue::Identifier(parse_dotted_square_bracket_identifier_value(p)?)
             }
             _ => unreachable!("invalid grammar"),
         };

--- a/tests/parser/identifier.rs
+++ b/tests/parser/identifier.rs
@@ -79,7 +79,7 @@ fn integer_index() {
         "networks[0].wifi",
         Expression::new(ExpressionValue::Identifier(Identifier::new(vec![
             IdentifierValue::Name("networks".to_string()),
-            IdentifierValue::IntegerIndex(0),
+            IdentifierValue::Index(0),
             IdentifierValue::Name("wifi".to_string())
         ])))
     );
@@ -91,7 +91,7 @@ fn string_index() {
         "people[`123-456-789`].first",
         Expression::new(ExpressionValue::Identifier(Identifier::new(vec![
             IdentifierValue::Name("people".to_string()),
-            IdentifierValue::StringIndex("123-456-789".to_string()),
+            IdentifierValue::Name("123-456-789".to_string()),
             IdentifierValue::Name("first".to_string())
         ])))
     );
@@ -103,9 +103,9 @@ fn indirect_index() {
         "people[people[0].id].first",
         Expression::new(ExpressionValue::Identifier(Identifier::new(vec![
             IdentifierValue::Name("people".to_string()),
-            IdentifierValue::IdentifierIndex(Identifier::new(vec![
+            IdentifierValue::Identifier(Identifier::new(vec![
                 IdentifierValue::Name("people".to_string()),
-                IdentifierValue::IntegerIndex(0),
+                IdentifierValue::Index(0),
                 IdentifierValue::Name("id".to_string()),
             ])),
             IdentifierValue::Name("first".to_string())
@@ -153,7 +153,7 @@ fn super_reserved_keyword() {
         "networks[0].super",
         Expression::new(ExpressionValue::Identifier(Identifier::new(vec![
             IdentifierValue::Name("networks".to_string()),
-            IdentifierValue::IntegerIndex(0),
+            IdentifierValue::Index(0),
             IdentifierValue::Super
         ])))
     );


### PR DESCRIPTION
Simplifies identifier:

* `IntegerIndex` -> `Index`
* Removed `StringIndex` (it's effectively the same things as `Name`)
* Renamed `IdentifierIndex` to `Identifier`

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>