### PR TITLE
Canonical identifier

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -352,6 +352,77 @@ impl Identifier {
 
         Ok(Identifier::new(result))
     }
+
+    /// Appends `IdentifierValue::Name` to the identifier
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - A name (object field, string index)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use balena_temen::ast::*;
+    ///
+    /// let identifier = Identifier::default()
+    ///     .name("wifi")
+    ///     .name("ssid");
+    ///
+    /// let parsed = "wifi.ssid".parse().unwrap();
+    ///
+    /// assert_eq!(identifier, parsed);
+    /// ```
+    pub fn name<S>(mut self, name: S) -> Identifier
+    where
+        S: Into<String>,
+    {
+        self.values.push(IdentifierValue::Name(name.into()));
+        self
+    }
+
+    /// Appends `IdentifierValue::Index` to the identifier
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - An array index
+    ///
+    /// ```rust
+    /// use balena_temen::ast::*;
+    ///
+    /// let identifier = Identifier::default()
+    ///     .name("networks")
+    ///     .index(0);
+    ///
+    /// let parsed = "networks[0]".parse().unwrap();
+    ///
+    /// assert_eq!(identifier, parsed);
+    /// ```
+    pub fn index(mut self, index: isize) -> Identifier {
+        self.values.push(IdentifierValue::Index(index));
+        self
+    }
+
+    /// Appends `IdentifierValue::Identifier` to the identifier
+    ///
+    /// # Arguments
+    ///
+    /// * `identifier` - An identifier index
+    ///
+    /// ```rust
+    /// use balena_temen::ast::*;
+    ///
+    /// let identifier = Identifier::default()
+    ///     .name("wifi")
+    ///     .identifier(Identifier::default().name("first_wifi_id"));
+    ///
+    /// let parsed = "wifi[first_wifi_id]".parse().unwrap();
+    ///
+    /// assert_eq!(identifier, parsed);
+    /// ```
+    pub fn identifier(mut self, identifier: Identifier) -> Identifier {
+        self.values.push(IdentifierValue::Identifier(identifier));
+        self
+    }
 }
 
 impl Default for Identifier {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -219,8 +219,8 @@ impl Identifier {
 
     /// Check if an identifier is canonical
     ///
-    /// An identifier is considered as canonical if all relative identifier values
-    /// (`IdentifierValue::This`, `IdentifierValue::Super`) are not present.
+    /// An identifier is considered as canonical if none relative identifier values
+    /// (`IdentifierValue::This`, `IdentifierValue::Super`) are present.
     ///
     /// It affects (checks) nested identifiers as well.
     ///

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -217,24 +217,140 @@ impl Identifier {
         Identifier { values }
     }
 
-    /// Check if an identifier is relative
+    /// Check if an identifier is canonical
     ///
-    /// An identifier is considered as a relative one if it starts with `this` or `super`
-    /// keyword.
-    pub fn is_relative(&self) -> bool {
+    /// An identifier is considered as canonical if all relative identifier values
+    /// (`IdentifierValue::This`, `IdentifierValue::Super`) are not present.
+    ///
+    /// It affects (checks) nested identifiers as well.
+    ///
+    /// # Examples
+    ///
+    /// Canonical identifiers.
+    ///
+    /// ```rust
+    /// use balena_temen::ast::*;
+    ///
+    /// let identifier: Identifier = "names.wifi".parse().unwrap();
+    /// assert!(identifier.is_canonical());
+    ///
+    /// let identifier: Identifier = "names.wifi[first].id".parse().unwrap();
+    /// assert!(identifier.is_canonical());
+    /// ```
+    ///
+    /// Not canonical identifiers.
+    ///
+    /// ```rust
+    /// use balena_temen::ast::*;
+    ///
+    /// let identifier: Identifier = "names.this".parse().unwrap();
+    /// assert!(!identifier.is_canonical());
+    ///
+    /// let identifier: Identifier = "names[this.index]".parse().unwrap();
+    /// assert!(!identifier.is_canonical());
+    /// ```
+    pub fn is_canonical(&self) -> bool {
+        for v in &self.values {
+            match v {
+                IdentifierValue::This | IdentifierValue::Super => return false,
+                IdentifierValue::Identifier(ref identifier) => {
+                    if !identifier.is_canonical() {
+                        return false;
+                    }
+                }
+                _ => {}
+            };
+        }
+
+        true
+    }
+
+    fn is_relative(&self) -> bool {
         if let Some(first) = self.values.first() {
-            first == &IdentifierValue::This || first == &IdentifierValue::Super
+            match first {
+                IdentifierValue::This | IdentifierValue::Super => true,
+                _ => false,
+            }
         } else {
             false
         }
     }
 
-    /// Check if an identifier is absolute
+    /// Returns the canonical, absolute, identifier with all intermediate
+    /// components normalized and nested identifiers canonicalized.
     ///
-    /// An identifier is considered as an absolute one if it does not start with `this`
-    /// or `super` keyword.
-    pub fn is_absolute(&self) -> bool {
-        !self.is_relative()
+    /// Nested identifiers (`IdentifierValue::Identifier`) are canonicalized
+    /// too.
+    ///
+    /// # Arguments
+    ///
+    /// * `position` - An identifier position
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use balena_temen::ast::*;
+    ///
+    /// let identifier: Identifier = "names".parse().unwrap();
+    /// assert_eq!(identifier.canonicalize(&Identifier::default()).unwrap(), identifier);
+    ///
+    /// let identifier: Identifier = "names.this.id.this.super".parse().unwrap();
+    /// let canonicalized: Identifier = "names".parse().unwrap();
+    /// assert_eq!(identifier.canonicalize(&Identifier::default()).unwrap(), canonicalized);
+    ///
+    /// let identifier: Identifier = "super.id".parse().unwrap();
+    /// let position: Identifier = "wifi[`zrzka`].ssid".parse().unwrap();
+    /// let canonicalized: Identifier = "wifi[`zrzka`].id".parse().unwrap();
+    /// assert_eq!(identifier.canonicalize(&position).unwrap(), canonicalized);
+    /// ```
+    pub fn canonicalize(&self, position: &Identifier) -> Result<Identifier> {
+        let position_values = if self.is_relative() {
+            // Identifier is relative, we must have non empty absolute identifier
+            if position.is_relative() {
+                return Err(Error::with_message("unable to canonicalize identifier")
+                    .context("reason", "identifier and position are relative identifiers")
+                    .context("identifier", format!("{:?}", self))
+                    .context("position", format!("{:?}", position)));
+            }
+            if position.values.is_empty() {
+                return Err(Error::with_message("unable to canonicalize identifier")
+                    .context("reason", "identifier is relative and position is empty")
+                    .context("identifier", format!("{:?}", self))
+                    .context("position", format!("{:?}", position)));
+            }
+            Some(position.values.iter())
+        } else {
+            None
+        };
+
+        let values = position_values.into_iter().flatten().chain(self.values.iter());
+
+        let mut result = vec![];
+        for value in values {
+            match value {
+                IdentifierValue::This => {
+                    // This resolves to self, we can remove it
+                }
+                IdentifierValue::Super => {
+                    // Super should resolve to parent, pop the latest identifier
+                    // from result
+                    result.pop().ok_or_else(|| {
+                        Error::with_message("unable to canonicalize identifier")
+                            .context("reason", "`super` can not be resolved")
+                    })?;
+                }
+                IdentifierValue::Identifier(ref identifier) => {
+                    // Canonicalize nested identifiers
+                    result.push(IdentifierValue::Identifier(identifier.canonicalize(position)?));
+                }
+                _ => {
+                    // Rest is just cloned
+                    result.push(value.clone());
+                }
+            }
+        }
+
+        Ok(Identifier::new(result))
     }
 }
 
@@ -377,5 +493,13 @@ impl FromStr for Expression {
 
     fn from_str(s: &str) -> Result<Expression> {
         parse(s)
+    }
+}
+
+impl FromStr for Identifier {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Identifier> {
+        parse(s)?.into_identifier()
     }
 }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -20,15 +20,9 @@ impl Lookup for Value {
     fn lookup_identifier<'a>(&'a self, identifier: &Identifier, position: &Identifier) -> Result<Cow<'a, Value>> {
         let mut lookup = LookupStack::new(self);
 
-        if identifier.is_relative() {
-            // Update stack with initial position
-            for position_value in position.values.iter() {
-                lookup.update_with_identifier_value(position_value, position)?;
-            }
-        }
+        let canonical = identifier.canonicalize(position)?;
 
-        // Update stack with either relative / absolute identifier, stack is prepared for both
-        for identifier_value in identifier.values.iter() {
+        for identifier_value in canonical.values.iter() {
             lookup.update_with_identifier_value(identifier_value, position)?;
         }
 


### PR DESCRIPTION
Fixed #22 

This PR contains:

* `Identifier` public API
  * `is_relative()` & `is_absolute()` removed
  * `is_canonical()` introduced
  * `canonicalize()` introduced
  * Add `impl FromStr for Identifier` to allow `"name".parse()` for identifiers, not just expressions
* Addresses `Value::Number` from the previous [PR](https://github.com/balena-io-modules/balena-temen/pull/23#discussion_r233838632)