### PR TITLE
Eval helper

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -385,12 +385,13 @@ impl Identifier {
     ///
     /// assert_eq!(identifier, parsed);
     /// ```
-    pub fn name<S>(mut self, name: S) -> Identifier
+    pub fn name<S>(self, name: S) -> Identifier
     where
         S: Into<String>,
     {
-        self.values.push(IdentifierValue::Name(name.into()));
-        self
+        let mut values = self.values;
+        values.push(IdentifierValue::Name(name.into()));
+        Identifier { values }
     }
 
     /// Appends `IdentifierValue::Index` to the identifier
@@ -410,9 +411,10 @@ impl Identifier {
     ///
     /// assert_eq!(identifier, parsed);
     /// ```
-    pub fn index(mut self, index: isize) -> Identifier {
-        self.values.push(IdentifierValue::Index(index));
-        self
+    pub fn index(self, index: isize) -> Identifier {
+        let mut values = self.values;
+        values.push(IdentifierValue::Index(index));
+        Identifier { values }
     }
 
     /// Appends `IdentifierValue::Identifier` to the identifier
@@ -432,9 +434,12 @@ impl Identifier {
     ///
     /// assert_eq!(identifier, parsed);
     /// ```
-    pub fn identifier(mut self, identifier: Identifier) -> Identifier {
-        self.values.push(IdentifierValue::Identifier(identifier));
-        self
+    pub fn identifier(self, identifier: Identifier) -> Identifier {
+        let mut values = self.values;
+        values.push(IdentifierValue::Identifier(identifier));
+        Identifier { values }
+    }
+
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -440,6 +440,13 @@ impl Identifier {
         Identifier { values }
     }
 
+    /// Returns `Identifier` with the last identifier value removed
+    pub fn pop(self) -> Result<Identifier> {
+        let mut values = self.values;
+        match values.pop() {
+            Some(_) => Ok(Identifier { values }),
+            None => Err(Error::with_message("unable to pop identifier")),
+        }
     }
 }
 

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -1,0 +1,253 @@
+use std::collections::HashMap;
+
+use crate::{
+    builtin::{
+        filter::{self, FilterFn},
+        function::{self, FunctionFn},
+    },
+    engine::Engine,
+};
+
+/// A custom engine builder
+///
+/// Allows to build an [`Engine`] with custom filters, functions or the evaluation keyword.
+///
+/// [`Engine`]: struct.Engine.html
+pub struct EngineBuilder {
+    functions: HashMap<String, FunctionFn>,
+    filters: HashMap<String, FilterFn>,
+    eval_keyword: Option<String>,
+}
+
+impl Default for EngineBuilder {
+    /// Creates new [`EngineBuilder`] with default filters, functions and the evaluation keyword
+    ///
+    /// [`EngineBuilder`]: struct.EngineBuilder.html
+    fn default() -> EngineBuilder {
+        EngineBuilder::new()
+            .filter("upper", filter::upper)
+            .filter("lower", filter::lower)
+            .filter("time", filter::time)
+            .filter("date", filter::date)
+            .filter("datetime", filter::datetime)
+            .filter("trim", filter::trim)
+            .filter("slugify", filter::slugify)
+            .function("uuidv4", function::uuidv4)
+            .function("now", function::now)
+    }
+}
+
+impl EngineBuilder {
+    /// Creates new, empty, [`EngineBuilder`]
+    ///
+    /// No filters and functions are registered.
+    ///
+    /// [`EngineBuilder`]: struct.EngineBuilder.html
+    fn new() -> EngineBuilder {
+        EngineBuilder {
+            functions: HashMap::new(),
+            filters: HashMap::new(),
+            eval_keyword: None,
+        }
+    }
+
+    /// Registers custom filter
+    ///
+    /// If a filter with the name already exists, it will be overwritten.
+    ///
+    /// Visit [`FilterFn`] to learn more about filters.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Custom filter name
+    /// * `filter` - Custom filter function
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use balena_temen::{
+    ///     ast::Identifier,
+    ///     Engine, EngineBuilder, Context, Value,
+    ///     error::*
+    /// };
+    /// use serde_json::json;
+    /// use std::collections::HashMap;
+    ///
+    /// fn text_filter(input: &Value, args: &HashMap<String, Value>, _: &mut Context) -> Result<Value> {
+    ///     let input = input.as_str()
+    ///         .ok_or_else(|| {
+    ///             Error::with_message("invalid input type")
+    ///                 .context("expected", "string")
+    ///                 .context("value", input.to_string())
+    ///     })?;
+    ///
+    ///     let trim = args.get("trim")
+    ///         .unwrap_or_else(|| &Value::Bool(false));
+    ///     let trim = trim
+    ///         .as_bool()
+    ///         .ok_or_else(|| {
+    ///             Error::with_message("invalid argument type")
+    ///                 .context("argument", "trim")
+    ///                 .context("expected", "boolean")
+    ///                 .context("value", trim.to_string())
+    ///         })?;
+    ///
+    ///     let upper = args.get("upper")
+    ///         .unwrap_or_else(|| &Value::Bool(false));
+    ///     let upper = upper
+    ///         .as_bool()
+    ///         .ok_or_else(|| {
+    ///             Error::with_message("invalid argument type")
+    ///                 .context("argument", "upper")
+    ///                 .context("expected", "boolean")
+    ///                 .context("value", trim.to_string())
+    ///         })?;
+    ///
+    ///     let result = match (trim, upper) {
+    ///         (false, false) => input.to_string(),
+    ///         (true, false) => input.trim().to_string(),
+    ///         (false, true) => input.to_uppercase(),
+    ///         (true, true) => input.trim().to_uppercase(),
+    ///     };
+    ///
+    ///     Ok(Value::String(result))
+    /// };
+    ///
+    /// let engine: Engine = EngineBuilder::default()
+    ///     .filter("text", text_filter)
+    ///     .into();
+    /// let mut ctx = Context::default();
+    /// let position = Identifier::default();
+    /// let data = Value::Null;
+    ///
+    /// assert_eq!(
+    ///     engine.eval("` abc ` | text", &position, &data, &mut ctx).unwrap(),
+    ///     json!(" abc ")
+    /// );
+    /// assert_eq!(
+    ///     engine.eval("` abc ` | text(trim=true)", &position, &data, &mut ctx).unwrap(),
+    ///     json!("abc")
+    /// );
+    /// assert_eq!(
+    ///     engine.eval("` abc ` | text(trim=true, upper=true)", &position, &data, &mut ctx).unwrap(),
+    ///     json!("ABC")
+    /// );
+    /// ```
+    ///
+    /// [`FilterFn`]: type.FilterFn.html
+    pub fn filter<S>(self, name: S, filter: FilterFn) -> EngineBuilder
+    where
+        S: Into<String>,
+    {
+        let mut filters = self.filters;
+        filters.insert(name.into(), filter);
+        EngineBuilder {
+            functions: self.functions,
+            filters,
+            eval_keyword: self.eval_keyword,
+        }
+    }
+
+    /// Registers custom function
+    ///
+    /// If a function with the name already exists, it will be overwritten.
+    ///
+    /// Visit [`FunctionFn`] to learn more about functions.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Custom function name
+    /// * `function` - Custom function function
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use balena_temen::{
+    ///     ast::Identifier,
+    ///     Engine, EngineBuilder, Context, Value,
+    ///     error::*
+    /// };
+    /// use serde_json::json;
+    /// use std::collections::HashMap;
+    ///
+    /// fn echo_function(args: &HashMap<String, Value>, _: &mut Context) -> Result<Value> {
+    ///     let value = match args.get("value") {
+    ///         Some(x) => {
+    ///             x.as_str().ok_or_else(|| {
+    ///                 Error::with_message("invalid argument type")
+    ///                     .context("expect", "string")
+    ///                     .context("value", x.to_string())
+    ///             })?
+    ///         },
+    ///         None => "echo"
+    ///     };
+    ///
+    ///     Ok(Value::String(value.to_string()))
+    /// };
+    ///
+    /// let engine: Engine = EngineBuilder::default()
+    ///     .function("echo", echo_function)
+    ///     .into();
+    /// let mut ctx = Context::default();
+    /// let position = Identifier::default();
+    /// let data = Value::Null;
+    ///
+    /// assert_eq!(
+    ///     engine.eval("echo()", &position, &data, &mut ctx).unwrap(),
+    ///     json!("echo")
+    /// );
+    /// assert_eq!(
+    ///     engine.eval("echo(value=`Hallo`)", &position, &data, &mut ctx).unwrap(),
+    ///     json!("Hallo")
+    /// );
+    /// assert!(
+    ///     engine.eval("echo(value=1)", &position, &data, &mut ctx).is_err()
+    /// );
+    /// ```
+    ///
+    /// [`FunctionFn`]: type.FunctionFn.html
+    pub fn function<S>(self, name: S, function: FunctionFn) -> EngineBuilder
+    where
+        S: Into<String>,
+    {
+        let mut functions = self.functions;
+        functions.insert(name.into(), function);
+        EngineBuilder {
+            functions,
+            filters: self.filters,
+            eval_keyword: self.eval_keyword,
+        }
+    }
+
+    /// Registers custom evaluation keyword
+    ///
+    /// Defaults to `$$eval` if no keyword is registered.
+    ///
+    /// # Arguments
+    ///
+    /// * `keyword` - An evaluation keyword
+    ///
+    /// # Examples
+    ///
+    // TODO Add example
+    pub fn eval_keyword<S>(self, keyword: S) -> EngineBuilder
+    where
+        S: Into<String>,
+    {
+        EngineBuilder {
+            functions: self.functions,
+            filters: self.filters,
+            eval_keyword: Some(keyword.into()),
+        }
+    }
+}
+
+impl From<EngineBuilder> for Engine {
+    fn from(builder: EngineBuilder) -> Engine {
+        Engine {
+            functions: builder.functions,
+            filters: builder.filters,
+            eval_keyword: builder.eval_keyword.unwrap_or_else(|| "$$eval".into()),
+        }
+    }
+}

--- a/src/engine/helper.rs
+++ b/src/engine/helper.rs
@@ -1,0 +1,275 @@
+use serde_json::Value;
+
+use crate::ast::*;
+use crate::context::Context;
+use crate::engine::Engine;
+use crate::error::*;
+
+/// Item to evaluate
+struct Item {
+    /// Item position
+    position: Identifier,
+    /// Item expression (`$$eval` value)
+    expression: String,
+}
+
+/// Creates an item to evaluate if applicable
+///
+/// `value` must be an object containing the `$$eval` keyword and value of this
+/// keyword must be a `String`.
+///
+/// # Arguments
+///
+/// * `value` - A JSON value to create item from
+/// * `position` - A JSON value position
+/// * `keyword` - An evaluation keyword
+fn item_to_eval(value: &Value, position: &Identifier, keyword: &str) -> Result<Option<Item>> {
+    match value {
+        Value::Object(ref object) => {
+            if let Some(ref value) = object.get(keyword) {
+                // Object with $$eval keyword, must be a string
+                let expression = value.as_str().ok_or_else(|| {
+                    Error::with_message("unable to evaluate")
+                        .context("reason", "eval keyword value is not a string")
+                        .context("value", value.to_string())
+                        .context("position", format!("{:?}", position))
+                })?;
+                Ok(Some(Item {
+                    position: position.clone(),
+                    expression: expression.to_string(),
+                }))
+            } else {
+                // Object, but not $$eval keyword
+                Ok(None)
+            }
+        }
+        _ => {
+            // Not an object, nothing to evaluate
+            Ok(None)
+        }
+    }
+}
+
+/// Creates list of items to evaluate
+///
+/// It traverses the whole JSON recuresively.
+///
+/// # Arguments
+///
+/// * `value` - A value to traverse
+/// * `position` - Current value position
+/// * `keyword` - An evaluation keyword
+fn items_to_eval(value: &Value, position: Identifier, keyword: &str) -> Result<Option<Vec<Item>>> {
+    match value {
+        Value::Null | Value::String(_) | Value::Number(_) | Value::Bool(_) => {
+            // There's nothing to evaluate
+            Ok(None)
+        }
+        Value::Array(ref array) => {
+            // We have to check if this array contains objects to evaluate
+            let mut result = vec![];
+
+            for (idx, value) in array.iter().enumerate() {
+                match items_to_eval(value, position.clone().index(idx as isize), keyword)? {
+                    Some(items) => result.extend(items),
+                    None => {}
+                };
+            }
+
+            if result.len() > 0 {
+                Ok(Some(result))
+            } else {
+                Ok(None)
+            }
+        }
+        Value::Object(ref object) => match item_to_eval(value, &position, keyword)? {
+            Some(item) => {
+                // Object contains $$eval and value is a string
+                Ok(Some(vec![item]))
+            }
+            None => {
+                // Object does not contain $$eval, check object key/value pairs recursively
+                let mut result = vec![];
+
+                for (k, v) in object {
+                    match items_to_eval(v, position.clone().name(k.to_string()), keyword)? {
+                        Some(items) => result.extend(items),
+                        None => {}
+                    };
+                }
+
+                if result.len() > 0 {
+                    Ok(Some(result))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    }
+}
+
+/// Replaces value in a JSON
+///
+/// # Arguments
+///
+/// * `data` - A JSON
+/// * `new_value` - New value to use
+/// * `position` - A position of the new value
+fn replace_value(data: Value, new_value: Value, position: &Identifier) -> Value {
+    if position.values.is_empty() {
+        // Empty position = root = whole JSON
+        return new_value;
+    }
+
+    let mut data = data;
+    let mut current = &mut data;
+    for value in &position.values {
+        match value {
+            // .unwrap()'s are safe - position was constructed by us
+            IdentifierValue::Name(ref name) => current = current.get_mut(name).unwrap(),
+            IdentifierValue::Index(ref index) => current = current.get_mut(*index as usize).unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
+    *current = new_value;
+    data
+}
+
+// This is pretty naive, multi pass evaluation. It works in this way:
+//
+//   * evaluate all items, one by one,
+//   * do not fail if it fails, just increase the counters
+//   * nothing failed? return what we have, success
+//   * at least one item failed to evaluate?
+//     * no item succeeded? return an error
+//   * try again with another pass
+//
+// It's good enough for now.
+//
+// We will see what kind of DSLs we will have and if we will need to create
+// dependency tree, detect circular dependencies, analyze if we can evaluate
+// before the actual evaluation, etc.
+fn eval_with_items(data: Value, items: Vec<Item>, engine: &Engine, context: &mut Context) -> Result<Value> {
+    let mut fail_counter;
+    let mut success_counter;
+    let mut data = data;
+
+    loop {
+        fail_counter = 0;
+        success_counter = 0;
+
+        for item in &items {
+            match engine.eval(&item.expression, &item.position, &data, context) {
+                Err(_) => fail_counter += 1,
+                Ok(new_value) => {
+                    data = replace_value(data, new_value, &item.position);
+                    success_counter += 1;
+                }
+            };
+        }
+
+        if fail_counter == 0 {
+            // Nothing failed, return what we have
+            return Ok(data);
+        }
+
+        if fail_counter > 0 && success_counter == 0 {
+            // Something failed, but not even one item was evaluated, another pass won't help, fail
+            return Err(Error::with_message("unable to evaluate"));
+        }
+
+        // Something failed here, but also at least one item was evaluated. Try
+        // another pass to check if we can evaluate more.
+    }
+}
+
+/// Evaluates the whole JSON
+///
+/// # Arguments
+///
+/// * `data` - A JSON to evaluate
+///
+/// # Examples
+///
+/// An object evaluation.
+///
+/// ```rust
+/// use balena_temen::{eval, Value};
+/// use serde_json::json;
+///
+/// let data = json!({
+///   "$$eval": "1 + 2"
+/// });
+///
+/// assert_eq!(eval(data).unwrap(), json!(3));
+/// ```
+///
+/// Chained dependencies evaluation.
+///
+/// ```rust
+/// use balena_temen::{eval, Value};
+/// use serde_json::json;
+///
+/// let data = json!({
+///     "ssid": "Zrzka 5G",
+///     "id": {
+///         "$$eval": "super.ssid | slugify"
+///     },
+///     "upperId": {
+///         "$$eval": "super.id | upper"
+///     }
+/// });
+///
+/// let evaluated = json!({
+///     "ssid": "Zrzka 5G",
+///     "id": "zrzka-5g",
+///     "upperId": "ZRZKA-5G"
+/// });
+///
+/// assert_eq!(eval(data).unwrap(), evaluated);
+/// ```
+pub fn eval(data: Value) -> Result<Value> {
+    let engine = Engine::default();
+    let mut context = Context::default();
+
+    match items_to_eval(&data, Identifier::default(), engine.eval_keyword())? {
+        Some(items) => eval_with_items(data, items, &engine, &mut context),
+        None => Ok(data),
+    }
+}
+
+/// Evaluates the whole JSON with custom [`Engine`]
+///
+/// # Arguments
+///
+/// * `data` - A JSON to evaluate
+///
+/// # Examples
+///
+/// ```rust
+/// use balena_temen::{Context, eval_with_engine, Engine, EngineBuilder, Value};
+/// use serde_json::json;
+///
+/// let mut context = Context::default();
+/// let engine: Engine = EngineBuilder::default()
+///     .eval_keyword("evalMePlease")
+///     .into();
+///
+/// let data = json!({
+///   "evalMePlease": "1 + 2"
+/// });
+///
+/// assert_eq!(eval_with_engine(data, &engine, &mut context).unwrap(), json!(3));
+/// ```
+///
+/// Check the [`eval`] function for more examples.
+///
+/// [`eval`]: fn.eval.html
+/// [`Engine`]: struct.Engine.html
+pub fn eval_with_engine(data: Value, engine: &Engine, context: &mut Context) -> Result<Value> {
+    match items_to_eval(&data, Identifier::default(), engine.eval_keyword())? {
+        Some(items) => eval_with_items(data, items, engine, context),
+        None => Ok(data),
+    }
+}

--- a/src/engine/lookup.rs
+++ b/src/engine/lookup.rs
@@ -5,20 +5,35 @@ use serde_json::Value;
 use crate::ast::*;
 use crate::error::*;
 
-/// Lookup identifier
-pub trait Lookup {
+/// Provide a way to lookup an identifier (variable) value
+pub struct Lookup<'a> {
+    /// Whole structure (JSON) with variable values
+    data: &'a Value,
+    /// Stack of values for every identifier component (variable name, array index, ...)
+    stack: Vec<&'a Value>,
+}
+
+impl<'a> Lookup<'a> {
+    pub fn new(data: &'a Value) -> Lookup<'a> {
+        Lookup {
+            data,
+            stack: vec![data],
+        }
+    }
+
     /// Lookup identifier (variable) value
     ///
     /// # Arguments
     ///
+    /// * `data` - Variable values (whole JSON)
     /// * `identifier` - An identifier (variable) to lookup
     /// * `position` - An initial position for relative lookups
-    fn lookup_identifier<'a>(&'a self, identifier: &Identifier, position: &Identifier) -> Result<Cow<'a, Value>>;
-}
-
-impl Lookup for Value {
-    fn lookup_identifier<'a>(&'a self, identifier: &Identifier, position: &Identifier) -> Result<Cow<'a, Value>> {
-        let mut lookup = LookupStack::new(self);
+    pub fn lookup_identifier<'b>(
+        data: &'b Value,
+        identifier: &Identifier,
+        position: &Identifier,
+    ) -> Result<Cow<'b, Value>> {
+        let mut lookup = Lookup::new(data);
 
         let canonical = identifier.canonicalize(position)?;
 
@@ -30,23 +45,6 @@ impl Lookup for Value {
             Error::with_message("unable to lookup identifier").context("reason", "empty stack = invalid identifier")
         })?);
         Ok(result)
-    }
-}
-
-/// Provide a way to lookup an identifier (variable) value
-pub struct LookupStack<'a> {
-    /// Whole structure (JSON) with variable values
-    root: &'a Value,
-    /// Stack of values for every identifier component (variable name, array index, ...)
-    stack: Vec<&'a Value>,
-}
-
-impl<'a> LookupStack<'a> {
-    pub fn new(root: &'a Value) -> LookupStack<'a> {
-        LookupStack {
-            root,
-            stack: vec![root],
-        }
     }
 
     /// Update stack with next identifier value
@@ -134,7 +132,7 @@ impl<'a> LookupStack<'a> {
                 //
                 // We have to create new Lookup structure and lookup this identifier
                 // from scratch to avoid existing stack modifications
-                match self.root.lookup_identifier(identifier, position)?.as_ref() {
+                match Lookup::lookup_identifier(self.data, identifier, position)?.as_ref() {
                     // If we were able to lookup the value, treat it as an String or Number index
                     Value::String(ref x) => {
                         self.update_with_identifier_value(&IdentifierValue::Name(x.to_string()), position)?

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6,258 +6,19 @@ use serde_json::{Number, Value};
 use crate::{
     ast::*,
     builtin::{
-        filter::{self, FilterFn},
-        function::{self, FunctionFn},
+        filter::FilterFn,
+        function::FunctionFn,
     },
     context::Context,
     error::*,
-    lookup::Lookup,
     utils::{RelativeEq, validate_f64}
 };
 
-/// A custom engine builder
-///
-/// Allows to build an [`Engine`] with custom filters, functions or the evaluation keyword.
-///
-/// [`Engine`]: struct.Engine.html
-pub struct EngineBuilder {
-    functions: HashMap<String, FunctionFn>,
-    filters: HashMap<String, FilterFn>,
-    eval_keyword: Option<String>,
-}
+use self::builder::EngineBuilder;
+use self::lookup::Lookup;
 
-impl Default for EngineBuilder {
-    /// Creates new [`EngineBuilder`] with default filters, functions and the evaluation keyword
-    ///
-    /// [`EngineBuilder`]: struct.EngineBuilder.html
-    fn default() -> EngineBuilder {
-        EngineBuilder::new()
-            .filter("upper", filter::upper)
-            .filter("lower", filter::lower)
-            .filter("time", filter::time)
-            .filter("date", filter::date)
-            .filter("datetime", filter::datetime)
-            .filter("trim", filter::trim)
-            .filter("slugify", filter::slugify)
-            .function("uuidv4", function::uuidv4)
-            .function("now", function::now)
-    }
-}
-
-impl EngineBuilder {
-    /// Creates new, empty, [`EngineBuilder`]
-    ///
-    /// No filters and functions are registered.
-    ///
-    /// [`EngineBuilder`]: struct.EngineBuilder.html
-    fn new() -> EngineBuilder {
-        EngineBuilder {
-            functions: HashMap::new(),
-            filters: HashMap::new(),
-            eval_keyword: None,
-        }
-    }
-
-    /// Registers custom filter
-    ///
-    /// If a filter with the name already exists, it will be overwritten.
-    ///
-    /// Visit [`FilterFn`] to learn more about filters.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Custom filter name
-    /// * `filter` - Custom filter function
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use balena_temen::{
-    ///     ast::Identifier,
-    ///     Engine, EngineBuilder, Context, Value,
-    ///     error::*
-    /// };
-    /// use serde_json::json;
-    /// use std::collections::HashMap;
-    ///
-    /// fn text_filter(input: &Value, args: &HashMap<String, Value>, _: &mut Context) -> Result<Value> {
-    ///     let input = input.as_str()
-    ///         .ok_or_else(|| {
-    ///             Error::with_message("invalid input type")
-    ///                 .context("expected", "string")
-    ///                 .context("value", input.to_string())
-    ///     })?;
-    ///
-    ///     let trim = args.get("trim")
-    ///         .unwrap_or_else(|| &Value::Bool(false));
-    ///     let trim = trim
-    ///         .as_bool()
-    ///         .ok_or_else(|| {
-    ///             Error::with_message("invalid argument type")
-    ///                 .context("argument", "trim")
-    ///                 .context("expected", "boolean")
-    ///                 .context("value", trim.to_string())
-    ///         })?;
-    ///
-    ///     let upper = args.get("upper")
-    ///         .unwrap_or_else(|| &Value::Bool(false));
-    ///     let upper = upper
-    ///         .as_bool()
-    ///         .ok_or_else(|| {
-    ///             Error::with_message("invalid argument type")
-    ///                 .context("argument", "upper")
-    ///                 .context("expected", "boolean")
-    ///                 .context("value", trim.to_string())
-    ///         })?;
-    ///
-    ///     let result = match (trim, upper) {
-    ///         (false, false) => input.to_string(),
-    ///         (true, false) => input.trim().to_string(),
-    ///         (false, true) => input.to_uppercase(),
-    ///         (true, true) => input.trim().to_uppercase(),
-    ///     };
-    ///
-    ///     Ok(Value::String(result))
-    /// };
-    ///
-    /// let engine: Engine = EngineBuilder::default()
-    ///     .filter("text", text_filter)
-    ///     .into();
-    /// let mut ctx = Context::default();
-    /// let position = Identifier::default();
-    /// let data = Value::Null;
-    ///
-    /// assert_eq!(
-    ///     engine.eval("` abc ` | text", &position, &data, &mut ctx).unwrap(),
-    ///     json!(" abc ")
-    /// );
-    /// assert_eq!(
-    ///     engine.eval("` abc ` | text(trim=true)", &position, &data, &mut ctx).unwrap(),
-    ///     json!("abc")
-    /// );
-    /// assert_eq!(
-    ///     engine.eval("` abc ` | text(trim=true, upper=true)", &position, &data, &mut ctx).unwrap(),
-    ///     json!("ABC")
-    /// );
-    /// ```
-    ///
-    /// [`FilterFn`]: type.FilterFn.html
-    pub fn filter<S>(self, name: S, filter: FilterFn) -> EngineBuilder
-    where
-        S: Into<String>,
-    {
-        let mut filters = self.filters;
-        filters.insert(name.into(), filter);
-        EngineBuilder {
-            functions: self.functions,
-            filters,
-            eval_keyword: self.eval_keyword,
-        }
-    }
-
-    /// Registers custom function
-    ///
-    /// If a function with the name already exists, it will be overwritten.
-    ///
-    /// Visit [`FunctionFn`] to learn more about functions.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Custom function name
-    /// * `function` - Custom function function
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use balena_temen::{
-    ///     ast::Identifier,
-    ///     Engine, EngineBuilder, Context, Value,
-    ///     error::*
-    /// };
-    /// use serde_json::json;
-    /// use std::collections::HashMap;
-    ///
-    /// fn echo_function(args: &HashMap<String, Value>, _: &mut Context) -> Result<Value> {
-    ///     let value = match args.get("value") {
-    ///         Some(x) => {
-    ///             x.as_str().ok_or_else(|| {
-    ///                 Error::with_message("invalid argument type")
-    ///                     .context("expect", "string")
-    ///                     .context("value", x.to_string())
-    ///             })?
-    ///         },
-    ///         None => "echo"
-    ///     };
-    ///
-    ///     Ok(Value::String(value.to_string()))
-    /// };
-    ///
-    /// let engine: Engine = EngineBuilder::default()
-    ///     .function("echo", echo_function)
-    ///     .into();
-    /// let mut ctx = Context::default();
-    /// let position = Identifier::default();
-    /// let data = Value::Null;
-    ///
-    /// assert_eq!(
-    ///     engine.eval("echo()", &position, &data, &mut ctx).unwrap(),
-    ///     json!("echo")
-    /// );
-    /// assert_eq!(
-    ///     engine.eval("echo(value=`Hallo`)", &position, &data, &mut ctx).unwrap(),
-    ///     json!("Hallo")
-    /// );
-    /// assert!(
-    ///     engine.eval("echo(value=1)", &position, &data, &mut ctx).is_err()
-    /// );
-    /// ```
-    ///
-    /// [`FunctionFn`]: type.FunctionFn.html
-    pub fn function<S>(self, name: S, function: FunctionFn) -> EngineBuilder
-    where
-        S: Into<String>,
-    {
-        let mut functions = self.functions;
-        functions.insert(name.into(), function);
-        EngineBuilder {
-            functions,
-            filters: self.filters,
-            eval_keyword: self.eval_keyword,
-        }
-    }
-
-    /// Registers custom evaluation keyword
-    ///
-    /// Defaults to `$$eval` if no keyword is registered.
-    ///
-    /// # Arguments
-    ///
-    /// * `keyword` - An evaluation keyword
-    ///
-    /// # Examples
-    ///
-    // TODO Add example
-    pub fn eval_keyword<S>(self, keyword: S) -> EngineBuilder
-    where
-        S: Into<String>,
-    {
-        EngineBuilder {
-            functions: self.functions,
-            filters: self.filters,
-            eval_keyword: Some(keyword.into()),
-        }
-    }
-}
-
-impl From<EngineBuilder> for Engine {
-    fn from(builder: EngineBuilder) -> Engine {
-        Engine {
-            functions: builder.functions,
-            filters: builder.filters,
-            eval_keyword: builder.eval_keyword.unwrap_or_else(|| "$$eval".into()),
-        }
-    }
-}
+pub(crate) mod builder;
+mod lookup;
 
 /// An expression evaluation engine
 pub struct Engine {
@@ -559,7 +320,7 @@ impl Engine {
             ExpressionValue::Integer(x) => Number::from(*x),
             ExpressionValue::Float(x) => Number::from_f64(*x).unwrap(),
             ExpressionValue::Identifier(x) => {
-                let value = &*data.lookup_identifier(x, position)?;
+                let value = &*Lookup::lookup_identifier(data, x, position)?;
                 match value {
                     Value::Number(num) => num.clone(),
                     _ => {
@@ -646,7 +407,7 @@ impl Engine {
             ExpressionValue::Float(x) => Cow::Owned(Value::Number(Number::from_f64(x).unwrap())),
             ExpressionValue::Boolean(x) => Cow::Owned(Value::Bool(x)),
             ExpressionValue::String(ref x) => Cow::Owned(Value::String(x.to_string())),
-            ExpressionValue::Identifier(ref x) => data.lookup_identifier(x, position)?.clone(),
+            ExpressionValue::Identifier(ref x) => Lookup::lookup_identifier(data, x, position)?.clone(),
             ExpressionValue::Math(_) => {
                 Cow::Owned(Value::Number(self.eval_as_number(expression, position, data, context)?))
             }
@@ -667,7 +428,7 @@ impl Engine {
                         ExpressionValue::String(ref x) => result.push_str(x),
                         ExpressionValue::Integer(x) => result.push_str(&format!("{}", x)),
                         ExpressionValue::Float(x) => result.push_str(&format!("{}", x)),
-                        ExpressionValue::Identifier(ref x) => match *data.lookup_identifier(x, position)? {
+                        ExpressionValue::Identifier(ref x) => match *Lookup::lookup_identifier(data, x, position)? {
                             Value::String(ref x) => result.push_str(x),
                             Value::Number(ref x) => result.push_str(&format!("{}", x)),
                             _ => {
@@ -719,7 +480,7 @@ impl Engine {
             }
             ExpressionValue::Boolean(x) => *x,
             ExpressionValue::Identifier(identifier) => {
-                let value = data.lookup_identifier(identifier, position)?;
+                let value = Lookup::lookup_identifier(data, identifier, position)?;
                 if let Value::Bool(value) = value.as_ref() {
                     *value
                 } else {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -18,6 +18,7 @@ use self::builder::EngineBuilder;
 use self::lookup::Lookup;
 
 pub(crate) mod builder;
+pub(crate) mod helper;
 mod lookup;
 
 /// An expression evaluation engine

--- a/src/error.rs
+++ b/src/error.rs
@@ -223,11 +223,11 @@ impl fmt::Display for Error {
                 context_indent = " | ";
             }
 
-            write!(f, "{} frame[{}]", frame_indent, frame_idx);
+            write!(f, "{} frame[{}]", frame_indent, frame_idx)?;
             if frame.name.is_some() {
-                writeln!(f, ": {}", frame.name.as_ref().unwrap());
+                writeln!(f, ": {}", frame.name.as_ref().unwrap())?;
             } else {
-                writeln!(f);
+                writeln!(f)?;
             }
 
             if !frame.context.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,10 @@ pub use crate::{
         function::FunctionFn,
     },
     context::Context,
-    engine::{Engine, EngineBuilder}
+    engine::{
+        builder::EngineBuilder,
+        Engine
+    }
 };
 
 pub(crate) mod builtin;
@@ -146,6 +149,5 @@ pub mod ast;
 mod context;
 mod engine;
 pub mod error;
-mod lookup;
 mod parser;
 mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,22 +17,58 @@
 //!
 //! # Examples
 //!
-//! ## High level
+//! ## Helpers
 //!
-//! Helpers are not implemented yet. You can track the implementation progress
-//! [here](https://github.com/balena-io-modules/balena-temen/issues/20).
+//! ### JSON evaluation
 //!
-//! ## Low level
+//! ```rust
+//! use balena_temen::{eval, Value};
+//! use serde_json::json;
 //!
-//! You should not use this functionality directly unless you need some really
-//! specific stuff.
+//! let data = json!({
+//!     "wifi": {
+//!         "ssid": "Balena Ltd",
+//!         "id": {
+//!             "$$eval": "super.ssid | slugify"
+//!         }
+//!     }
+//! });
+//! let evaluated = json!({
+//!     "wifi": {
+//!         "ssid": "Balena Ltd",
+//!         "id": "balena-ltd"
+//!     }
+//! });
+//! assert_eq!(eval(data).unwrap(), evaluated);
+//! ```
 //!
-//! ### Expression evaluation
+//! ### JSON with custom evaluation keyword
+//!
+//! ```rust
+//! use balena_temen::{Context, Engine, EngineBuilder, eval_with_engine, Value};
+//! use serde_json::json;
+//!
+//! let data = json!({
+//!     "evalMePlease": "3 + 5 * 2"
+//! });
+//! let evaluated = json!(13);
+//!
+//! let mut ctx = Context::default();
+//! let engine: Engine = EngineBuilder::default()
+//!     .eval_keyword("evalMePlease")
+//!     .into();
+//!
+//! assert_eq!(eval_with_engine(data, &engine, &mut ctx).unwrap(), evaluated);
+//! ```
+//!
+//! ## Intermediate
+//!
+//! ### Single expression evaluation
 //!
 //! ```rust
 //! use balena_temen::{
-//!   ast::Identifier,
-//!   Engine, Context, Value
+//!     ast::Identifier,
+//!     Engine, Context, Value
 //! };
 //! use serde_json::json;
 //!
@@ -52,12 +88,12 @@
 //! );
 //! ```
 //!
-//! ### Logical expression evaluation
+//! ### Single logical expression evaluation
 //!
 //! ```rust
 //! use balena_temen::{
-//!   ast::Identifier,
-//!   Engine, Context, Value
+//!     ast::Identifier,
+//!     Engine, Context, Value
 //! };
 //! use serde_json::json;
 //!
@@ -81,6 +117,8 @@
 //!     json!(true)
 //! );
 //! ```
+//!
+//! ## Advanced
 //!
 //! ### Custom functions and filters
 //!
@@ -122,6 +160,26 @@
 //!
 //! Visit [ast] module documentation for more info.
 //!
+//! ### Identifier parsing
+//!
+//! ```rust
+//! use balena_temen::ast::*;
+//!
+//! let s = "wifi.networks[0].ssid";
+//!
+//! // Parse it
+//! let parsed: Identifier = s.parse().unwrap();
+//!
+//! // Create manually
+//! let manual = Identifier::default()
+//!     .name("wifi")
+//!     .name("networks")
+//!     .index(0)
+//!     .name("ssid");
+//!
+//! assert_eq!(parsed, manual);
+//! ```
+//!
 //! [balena]: https://www.balena.io
 //! [ast]: ast/index.html
 //! [`EngineBuilder::function`]: struct.EngineBuilder.html#method.function
@@ -139,7 +197,11 @@ pub use crate::{
     context::Context,
     engine::{
         builder::EngineBuilder,
-        Engine
+        Engine,
+        helper::{
+            eval,
+            eval_with_engine
+        }
     }
 };
 

--- a/tests/engine/helper.rs
+++ b/tests/engine/helper.rs
@@ -1,0 +1,87 @@
+use serde_json::json;
+
+use balena_temen::{Context, Engine, EngineBuilder, eval, eval_with_engine};
+
+#[test]
+fn primitive_types_pass_through() {
+    assert_eq!(eval(json!(true)).unwrap(), json!(true));
+    assert_eq!(eval(json!(10)).unwrap(), json!(10));
+    assert_eq!(eval(json!(10.5)).unwrap(), json!(10.5));
+    assert_eq!(eval(json!("hallo")).unwrap(), json!("hallo"));
+}
+
+#[test]
+fn root_object() {
+    assert_eq!(eval(json!({"$$eval": "1 + 2"})).unwrap(), json!(3));
+}
+
+#[test]
+fn nested_object() {
+    assert_eq!(
+        eval(json!({"nested": {"$$eval": "1 + 2"}})).unwrap(),
+        json!({"nested": 3})
+    );
+}
+
+#[test]
+fn array() {
+    let data = json!([
+        "a",
+        "b",
+        {
+            "$$eval": "`C` | lower"
+        },
+        "d"
+    ]);
+
+    assert_eq!(eval(data).unwrap(), json!(["a", "b", "c", "d"]));
+}
+
+#[test]
+fn chained_references() {
+    let data = json!({
+        "first": "a",
+        "second": {
+            "$$eval": "first ~ `a`"
+        },
+        "third": {
+            "$$eval": "second ~ `a`"
+        },
+        "fourth": {
+            "$$eval": "third ~ `a`"
+        },
+    });
+    let evaluated = json!({
+        "first": "a",
+        "second": "aa",
+        "third": "aaa",
+        "fourth": "aaaa"
+    });
+
+    assert_eq!(eval(data).unwrap(), evaluated);
+}
+
+#[test]
+fn fail_on_circular_dependencies() {
+    let data = json!({
+        "first": {
+            "$$eval": "second"
+        },
+        "second": {
+            "$$eval": "first"
+        }
+    });
+
+    assert!(eval(data).is_err());
+}
+
+#[test]
+fn custom_keyword() {
+    let engine: Engine = EngineBuilder::default().eval_keyword("evalMePlease").into();
+    let mut context = Context::default();
+
+    assert_eq!(
+        eval_with_engine(json!({"evalMePlease": "1 + 2"}), &engine, &mut context).unwrap(),
+        json!(3)
+    );
+}

--- a/tests/engine/mod.rs
+++ b/tests/engine/mod.rs
@@ -1,2 +1,3 @@
 mod eval;
 mod eval_as_bool;
+mod helper;


### PR DESCRIPTION
Fixes #20 

This PR contains:

* `eval` & `eval_with_engine` helper functions
* `Identifier` methods signature change (removed `mut`) & `pop` method added
* Fixed lookup - it's an error if the result is an object with `$$eval` keyword

There's probably nothing more to implement now. I'll write better readme (separate PR) and remaining issues are on hold.