### PR TITLE
Publish on tag only

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -8,6 +8,11 @@ if [ -z ${TRAVIS_TAG+x} ]; then
     exit 0
 fi
 
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+    echo "Not a master branch, skipping"
+    exit 0
+fi
+
 # Giovanni, following must be called only when:
 #
 #  * `branch == master`

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -2,8 +2,17 @@
 
 set -e
 
-if [ "$TRAVIS_BRANCH" = "master" ]; then
-    # repo.yml.type == rust-* (rust-crate, rust-crate-wasm)
-    cargo login "$CARGO_API_TOKEN"
-    cargo publish
+if [ -z ${TRAVIS_TAG+x} ]; then
+    # Do not publish if there's no TRAVIS_TAG set
+    echo "TRAVIS_TAG not set, skipping"
+    exit 0
 fi
+
+# Giovanni, following must be called only when:
+#
+#  * `branch == master`
+#  * on a commit with bumped version
+
+# repo.yml.type == rust-* (rust-crate, rust-crate-wasm)
+cargo login "$CARGO_API_TOKEN"
+cargo publish


### PR DESCRIPTION
I don't like manual cancelling, so, we should publish only and only if `TRAVIS_TAG` is set, which means that versionist did release the new version.

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>