### PR TITLE
Fix wasm builtin functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ deploy:
 addons:
   firefox: latest
   chrome: stable
+
+notifications:
+  email:
+    on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,12 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 slug = "0.1"
-uuid = { version = "0.7", features = ["v4"] }
+uuid = { features = ["v4"], git = "https://github.com/zrzka/uuid.git", branch = "feature/wasm" }
 
 [target.wasm32-unknown-unknown.dependencies]
-wasm-bindgen= { version="0.2", features = ["serde-serialize"] }
 console_error_panic_hook = "0.1"
+uuid = { features = ["wasm-bindgen"], git = "https://github.com/zrzka/uuid.git", branch = "feature/wasm" }
+wasm-bindgen= { version="0.2", features = ["serde-serialize"] }
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,31 +10,59 @@ description = "Templating engine for (not just) JSON"
 categories = ["parsing", "template-engine", "wasm"]
 readme = "README.md"
 
+[lib]
+crate-type = ["lib", "cdylib"]
+
 [badges]
 travis-ci = { repository = "balena-io-modules/balena-temen", branch = "master" }
 
-[dependencies]
-approx = "0.3"
+[dependencies.approx]
+version = "0.3"
+
+[dependencies.chrono]
 # https://github.com/balena-io-modules/balena-temen/issues/37
-chrono = { git = "https://github.com/jjpe/chrono", rev = "52adf963e6e98cd75a4c4523abd7a1465e2ac63d" }
-lazy_static = "1"
-pest = "2"
-pest_derive = "2"
-serde = "1"
-serde_derive = "1"
-serde_json = "1"
-slug = "0.1"
+git = "https://github.com/jjpe/chrono"
+rev = "52adf963e6e98cd75a4c4523abd7a1465e2ac63d"
+
+[dependencies.lazy_static]
+version = "1"
+
+[dependencies.pest]
+version = "2"
+
+[dependencies.pest_derive]
+version = "2"
+
+[dependencies.serde]
+version = "1"
+
+[dependencies.serde_derive]
+version = "1"
+
+[dependencies.serde_json]
+version = "1"
+
+[dependencies.slug]
+version = "0.1"
+
+[dependencies.uuid]
 # https://github.com/balena-io-modules/balena-temen/issues/35
-uuid = { features = ["v4"], git = "https://github.com/zrzka/uuid.git", branch = "feature/wasm" }
+git = "https://github.com/zrzka/uuid.git"
+branch = "feature/wasm"
+features = ["v4"]
 
-[target.wasm32-unknown-unknown.dependencies]
-console_error_panic_hook = "0.1"
+[target.wasm32-unknown-unknown.dependencies.console_error_panic_hook]
+version = "0.1"
+
+[target.wasm32-unknown-unknown.dependencies.uuid]
 # https://github.com/balena-io-modules/balena-temen/issues/35
-uuid = { features = ["wasm-bindgen"], git = "https://github.com/zrzka/uuid.git", branch = "feature/wasm" }
-wasm-bindgen= { version="0.2", features = ["serde-serialize"] }
+git = "https://github.com/zrzka/uuid.git"
+branch = "feature/wasm"
+features = ["wasm-bindgen"]
 
-[target.wasm32-unknown-unknown.dev-dependencies]
-wasm-bindgen-test = "0.2"
+[target.wasm32-unknown-unknown.dependencies.wasm-bindgen]
+version = "0.2"
+features = ["serde-serialize"]
 
-[lib]
-crate-type = ["lib", "cdylib"]
+[target.wasm32-unknown-unknown.dev-dependencies.wasm-bindgen-test]
+version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "balena-io-modules/balena-temen", branch = "master" }
 
 [dependencies]
 approx = "0.3"
-chrono = "0.4"
+chrono = { git = "https://github.com/jjpe/chrono", rev = "52adf963e6e98cd75a4c4523abd7a1465e2ac63d" }
 lazy_static = "1"
 pest = "2"
 pest_derive = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ travis-ci = { repository = "balena-io-modules/balena-temen", branch = "master" }
 
 [dependencies]
 approx = "0.3"
+# https://github.com/balena-io-modules/balena-temen/issues/37
 chrono = { git = "https://github.com/jjpe/chrono", rev = "52adf963e6e98cd75a4c4523abd7a1465e2ac63d" }
 lazy_static = "1"
 pest = "2"
@@ -23,10 +24,12 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 slug = "0.1"
+# https://github.com/balena-io-modules/balena-temen/issues/35
 uuid = { features = ["v4"], git = "https://github.com/zrzka/uuid.git", branch = "feature/wasm" }
 
 [target.wasm32-unknown-unknown.dependencies]
 console_error_panic_hook = "0.1"
+# https://github.com/balena-io-modules/balena-temen/issues/35
 uuid = { features = ["wasm-bindgen"], git = "https://github.com/zrzka/uuid.git", branch = "feature/wasm" }
 wasm-bindgen= { version="0.2", features = ["serde-serialize"] }
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -21,7 +21,13 @@ echo "Testing Rust crate..."
 cargo test
 
 echo "Trying to package Rust crate..."
-cargo package
+
+CARGO_PACKAGE_ARGS=''
+if ! [ "$CI" = true ]; then
+    # Allow to test uncommitted changes locally
+    CARGO_PACKAGE_ARGS='--allow-dirty'
+fi
+cargo package "${CARGO_PACKAGE_ARGS}"
 
 
 #--------------------------- another repo.org.type ----------------------------#

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -27,7 +27,7 @@ if ! [ "$CI" = true ]; then
     # Allow to test uncommitted changes locally
     CARGO_PACKAGE_ARGS='--allow-dirty'
 fi
-cargo package "${CARGO_PACKAGE_ARGS}"
+cargo package ${CARGO_PACKAGE_ARGS}
 
 
 #--------------------------- another repo.org.type ----------------------------#

--- a/docs/expression.md
+++ b/docs/expression.md
@@ -271,11 +271,6 @@ Functions can be called without arguments (`uuidv4()`) or with named arguments
 | [`uuidv4`](#function-uuidv4) | Generates random UUID v4 |
 | [`now`](#function-now) | Returns the local date time / timestamp |
 
-**WARNING**: None of these functions do work if `balena-temen` NPM package is used.
-See [#35](https://github.com/balena-io-modules/balena-temen/issues/35) and
-[#37](https://github.com/balena-io-modules/balena-temen/issues/37). Waiting
-for upstream fixes. There're no issues if you do use `balena-temen` as a Rust crate.
-
 #### Function uuidv4
 
 Generates random UUID v4 in a hexadecimal, lower case, notation.

--- a/node/tests/package.json
+++ b/node/tests/package.json
@@ -1,7 +1,7 @@
 {
     "name": "node-integration-tests",
     "scripts": {
-        "test": "jest"
+        "test": "jest --env node"
     },
     "dependencies": {
         "balena-temen": "file:../../target/npm/pkg"

--- a/node/tests/src/builtin/now.test.js
+++ b/node/tests/src/builtin/now.test.js
@@ -1,0 +1,29 @@
+const bt = require('balena-temen');
+
+test('now() generates timestamp', () => {
+    const result = {
+        timestamp: expect.any(Number)
+    };
+
+    expect(
+        bt.evaluate({
+            "timestamp": {
+                "$$eval": "now(timestamp=true)"
+            }
+        })
+    ).toMatchObject(result);
+});
+
+test('now() generates rfc 3339', () => {
+    const result = {
+        date: expect.stringMatching(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\+[0-9]{2}:[0-9]{2}$/)
+    };
+
+    expect(
+        bt.evaluate({
+            "date": {
+                "$$eval": "now()"
+            }
+        })
+    ).toMatchObject(result);
+});

--- a/node/tests/src/builtin/uuidv4.test.js
+++ b/node/tests/src/builtin/uuidv4.test.js
@@ -1,0 +1,15 @@
+const bt = require('balena-temen');
+
+test('uuidv4() generates proper random UUID', () => {
+    const result = {
+        id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    };
+
+    expect(
+        bt.evaluate({
+            "id": {
+                "$$eval": "uuidv4()"
+            }
+        })
+    ).toMatchObject(result);
+});


### PR DESCRIPTION
* Adds temporary workaround for `now()` & `uuidv4()` for the wasm (#37 & #35)
* Adds node tests for these two functions to catch similar issues in the future
* Cargo.toml cleanup
* Removes note from the docs about not working fns for the wasm
* Adds `--allow-dirty` if the script is run locally