### PR TITLE
Do not require jest to be installed globally

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -45,8 +45,5 @@ nvm install
 nvm use
 echo "NodeJS version $(node --version)"
 
-echo "Installing jest..."
-npm install -g jest
-
 echo "Installing wasm-pack..."
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f


### PR DESCRIPTION
npm, when running tests pulls in binaries provided by dependencies into
scope, so the jest binary should be there already, without the need to
be installed globally on the machine.