### PR TITLE
Rename $$eval to $$formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,23 @@ This library is written in the Rust language and can be used:
 * [Expression language documentation]
 * [Changelog]
 
-## Usage 
+## Breaking changes
+
+### Version 0.1
+
+`$$eval` keyword was renamed to `$$formula`. You can still use `$$eval` if you want
+by instantiating your own [Engine](https://docs.rs/balena-temen/latest/balena_temen/struct.Engine.html)
+with the [EngineBuilder](https://docs.rs/balena-temen/latest/balena_temen/struct.EngineBuilder.html) and
+[custom eval keyword](https://docs.rs/balena-temen/latest/balena_temen/struct.EngineBuilder.html#method.eval_keyword)
+ registration.
+
+## Usage
 
 ### Rust
 
 Add as a dependency to your `Cargo.toml`:
 
-```
+```toml
 [dependencies]
 balena-temen = "0.1"
 ```
@@ -58,7 +68,7 @@ let data = json!({
     "wifi": {
         "ssid": "Balena Ltd",
         "id": {
-            "$$eval": "super.ssid | slugify"
+            "$$formula": "super.ssid | slugify"
         }
     }
 });
@@ -76,7 +86,7 @@ assert_eq!(evaluate(data).unwrap(), evaluated);
 
 Install via npm
 
-```
+```sh
 npm install --save balena-temen
 ```
 
@@ -89,7 +99,7 @@ console.log(
     bt.evaluate({
         "ssid": "Some Cool SSID!",
         "id": {
-            "$$eval": "super.ssid | slugify"
+            "$$formula": "super.ssid | slugify"
         }
     })
 );

--- a/docs/expression.md
+++ b/docs/expression.md
@@ -1,32 +1,32 @@
 # Expression language
 
 The expression language inspiration comes from:
- 
+
 * [Jinja2](http://jinja.pocoo.org/docs/2.10/)
 * [Django](https://docs.djangoproject.com/en/2.1/intro/overview/#design-your-templates)
 * [Tera](https://github.com/Keats/tera) crate by [Vincent Prouillet](https://github.com/Keats)
 
-## Evaluation
+## Formula evaluation
 
 Templating engine allows you to specify dynamic value for any object field
-with the `$$eval` keyword. Following example shows how to generate UUID v4 value
+with the `$$formula` keyword. Following example shows how to generate UUID v4 value
 for the `id` field.
 
 ```json
 {
     "id": {
-        "$$eval": "uuidv4()"
+        "$$formula": "uuidv4()"
     }
 }
 ```
 
-The `$$eval` keyword supports:
- 
+The `$$formula` keyword supports:
+
 * literals
 * variable access (= JSON fields)
 * expressions with arithmetic, relational and logical operators
 * filters (variable modification)
-* functions (generators) 
+* functions (generators)
 
 ## Grammar
 
@@ -57,7 +57,7 @@ Given the following JSON:
         },
         {
             "ssid": "Balena Guest"
-        }    
+        }
     ]
 }
 ```
@@ -76,13 +76,13 @@ Given the following JSON:
     "wifi": {
         "ssid": "Balena Guest",
         "id": {
-            "$$eval": "super.ssid | slugify"
-        }        
+            "$$formula": "super.ssid | slugify"
+        }
     }
 }
 ```
 
-* `wifi.id` contains the `$$eval` keyword with the `super.ssid | slugify` value
+* `wifi.id` contains the `$$formula` keyword with the `super.ssid | slugify` value
 * `super` is evaluated as the `wifi` object
 * `super.ssid` is evaluated as the `wifi.ssid` field
 * `wifi.ssid` is evaluated as the `"Balena Guest"` string
@@ -111,12 +111,12 @@ Square brackets allows you to use variables as well. Given the following JSON:
         }
     },
     "bossCompanyName": {
-        "$$eval": "people[bossId].company"
+        "$$formula": "people[bossId].company"
     }
 }
-``` 
+```
 
-* `bossCompanyName` contains the `$$eval` keyword with the `people[bossId].company` value
+* `bossCompanyName` contains the `$$formula` keyword with the `people[bossId].company` value
 * `bossId` is a variable (no `''`, `""` or back ticks) and is evaluated as the `"123"` string
 * the intermediate expression is `people["123"].company`
 * `people["123"]` is evaluated as the `{ "company": "Balena" }` object
@@ -170,7 +170,7 @@ Example:
 ```json
 {
     "id": {
-        "$$eval": "super.ssid | lower"
+        "$$formula": "super.ssid | lower"
     },
     "ssid": "Balena"
 }

--- a/examples/browser/index.js
+++ b/examples/browser/index.js
@@ -3,7 +3,7 @@ import * as bt from "balena-temen";
 const initialValue = {
     "ssid": "Some Cool SSID Network!",
     "id": {
-        "$$eval": "super.ssid | slugify"
+        "$$formula": "super.ssid | slugify"
     }
 }
 const stringify = (value) => JSON.stringify(value, null, 2)

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -4,7 +4,7 @@ console.log(
     bt.evaluate({
         "ssid": "Some Cool SSID!",
         "id": {
-            "$$eval": "super.ssid | slugify"
+            "$$formula": "super.ssid | slugify"
         }
     })
 );

--- a/node/tests/src/builtin/now.test.js
+++ b/node/tests/src/builtin/now.test.js
@@ -8,7 +8,7 @@ test('now() generates timestamp', () => {
     expect(
         bt.evaluate({
             "timestamp": {
-                "$$eval": "now(timestamp=true)"
+                "$$formula": "now(timestamp=true)"
             }
         })
     ).toMatchObject(result);
@@ -22,7 +22,7 @@ test('now() generates rfc 3339', () => {
     expect(
         bt.evaluate({
             "date": {
-                "$$eval": "now()"
+                "$$formula": "now()"
             }
         })
     ).toMatchObject(result);

--- a/node/tests/src/builtin/uuidv4.test.js
+++ b/node/tests/src/builtin/uuidv4.test.js
@@ -8,7 +8,7 @@ test('uuidv4() generates proper random UUID', () => {
     expect(
         bt.evaluate({
             "id": {
-                "$$eval": "uuidv4()"
+                "$$formula": "uuidv4()"
             }
         })
     ).toMatchObject(result);

--- a/node/tests/src/evaluate.test.js
+++ b/node/tests/src/evaluate.test.js
@@ -4,11 +4,11 @@ test('evaluate fn succeeds', () => {
     expect(
         bt.evaluate({
             "math": {
-                "$$eval": "5 + 10"
+                "$$formula": "5 + 10"
             }
         })
     ).toEqual(
-        {"math": 15}
+        { "math": 15 }
     );
 });
 
@@ -17,7 +17,7 @@ test('evaluate fn throws', () => {
         () => {
             bt.evaluate({
                 "prop": {
-                    "$$eval": "super.notExistingProperty"
+                    "$$formula": "super.notExistingProperty"
                 }
             });
         }

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -221,7 +221,7 @@ impl EngineBuilder {
 
     /// Registers custom evaluation keyword
     ///
-    /// Defaults to `$$eval` if no keyword is registered.
+    /// Defaults to `$$formula` if no keyword is registered.
     ///
     /// # Arguments
     ///
@@ -247,7 +247,7 @@ impl From<EngineBuilder> for Engine {
         Engine {
             functions: builder.functions,
             filters: builder.filters,
-            eval_keyword: builder.eval_keyword.unwrap_or_else(|| "$$eval".into()),
+            eval_keyword: builder.eval_keyword.unwrap_or_else(|| "$$formula".into()),
         }
     }
 }

--- a/src/engine/helper.rs
+++ b/src/engine/helper.rs
@@ -9,13 +9,13 @@ use crate::error::*;
 struct Item {
     /// Item position
     position: Identifier,
-    /// Item expression (`$$eval` value)
+    /// Item expression (`$$formula` value)
     expression: String,
 }
 
 /// Creates an item to evaluate if applicable
 ///
-/// `value` must be an object containing the `$$eval` keyword and value of this
+/// `value` must be an object containing the `$$formula` keyword and value of this
 /// keyword must be a `String`.
 ///
 /// # Arguments
@@ -27,7 +27,7 @@ fn item_to_eval(value: &Value, position: &Identifier, keyword: &str) -> Result<O
     match value {
         Value::Object(ref object) => {
             if let Some(ref value) = object.get(keyword) {
-                // Object with $$eval keyword, must be a string
+                // Object with $$formula keyword, must be a string
                 let expression = value.as_str().ok_or_else(|| {
                     Error::with_message("unable to evaluate")
                         .context("reason", "eval keyword value is not a string")
@@ -39,7 +39,7 @@ fn item_to_eval(value: &Value, position: &Identifier, keyword: &str) -> Result<O
                     expression: expression.to_string(),
                 }))
             } else {
-                // Object, but not $$eval keyword
+                // Object, but not $$formula keyword
                 Ok(None)
             }
         }
@@ -83,11 +83,11 @@ fn items_to_eval(value: &Value, position: &Identifier, keyword: &str) -> Result<
         }
         Value::Object(ref object) => match item_to_eval(value, &position, keyword)? {
             Some(item) => {
-                // Object contains $$eval and value is a string
+                // Object contains $$formula and value is a string
                 Ok(Some(vec![item]))
             }
             None => {
-                // Object does not contain $$eval, check object key/value pairs recursively
+                // Object does not contain $$formula, check object key/value pairs recursively
                 let mut result = vec![];
 
                 for (k, v) in object {
@@ -202,7 +202,7 @@ pub fn eval(data: Value) -> Result<Value> {
 /// use serde_json::json;
 ///
 /// let data = json!({
-///   "$$eval": "1 + 2"
+///   "$$formula": "1 + 2"
 /// });
 ///
 /// assert_eq!(evaluate(data).unwrap(), json!(3));
@@ -217,10 +217,10 @@ pub fn eval(data: Value) -> Result<Value> {
 /// let data = json!({
 ///     "ssid": "Zrzka 5G",
 ///     "id": {
-///         "$$eval": "super.ssid | slugify"
+///         "$$formula": "super.ssid | slugify"
 ///     },
 ///     "upperId": {
-///         "$$eval": "super.id | upper"
+///         "$$formula": "super.id | upper"
 ///     }
 /// });
 ///
@@ -322,7 +322,7 @@ pub mod wasm {
             let input = json!({
                 "number": 3,
                 "value": {
-                    "$$eval": "super.number + 5"
+                    "$$formula": "super.number + 5"
                 }
             });
             let js_input = JsValue::from_serde(&input).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!     "wifi": {
 //!         "ssid": "Balena Ltd",
 //!         "id": {
-//!             "$$eval": "super.ssid | slugify"
+//!             "$$formula": "super.ssid | slugify"
 //!         }
 //!     }
 //! });

--- a/tests/engine/helper.rs
+++ b/tests/engine/helper.rs
@@ -12,13 +12,13 @@ fn primitive_types_pass_through() {
 
 #[test]
 fn root_object() {
-    assert_eq!(evaluate(json!({"$$eval": "1 + 2"})).unwrap(), json!(3));
+    assert_eq!(evaluate(json!({"$$formula": "1 + 2"})).unwrap(), json!(3));
 }
 
 #[test]
 fn nested_object() {
     assert_eq!(
-        evaluate(json!({"nested": {"$$eval": "1 + 2"}})).unwrap(),
+        evaluate(json!({"nested": {"$$formula": "1 + 2"}})).unwrap(),
         json!({"nested": 3})
     );
 }
@@ -29,7 +29,7 @@ fn array() {
         "a",
         "b",
         {
-            "$$eval": "`C` | lower"
+            "$$formula": "`C` | lower"
         },
         "d"
     ]);
@@ -42,13 +42,13 @@ fn chained_references() {
     let data = json!({
         "first": "a",
         "second": {
-            "$$eval": "first ~ `a`"
+            "$$formula": "first ~ `a`"
         },
         "third": {
-            "$$eval": "second ~ `a`"
+            "$$formula": "second ~ `a`"
         },
         "fourth": {
-            "$$eval": "third ~ `a`"
+            "$$formula": "third ~ `a`"
         },
     });
     let evaluated = json!({
@@ -65,10 +65,10 @@ fn chained_references() {
 fn fail_on_circular_dependencies() {
     let data = json!({
         "first": {
-            "$$eval": "second"
+            "$$formula": "second"
         },
         "second": {
-            "$$eval": "first"
+            "$$formula": "first"
         }
     });
 


### PR DESCRIPTION
Marked as a minor change, because it's a breaking change. `$$eval` was renamed to `$$formula`.

Change-type: minor
Signed-off-by: Robert Vojta <robert@balena.io>