### PR TITLE
Calculations fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ This library is written in the Rust language and can be used:
 
 ## Breaking changes
 
+### Version 0.2
+
+* All function and filter identifiers were uppercased
+  * An example `uuidv4()` -> `UUIDV4()`
+
 ### Version 0.1
 
 `$$eval` keyword was renamed to `$$formula`. You can still use `$$eval` if you want

--- a/docs/expression.md
+++ b/docs/expression.md
@@ -15,7 +15,7 @@ for the `id` field.
 ```json
 {
     "id": {
-        "$$formula": "uuidv4()"
+        "$$formula": "UUIDV4()"
     }
 }
 ```
@@ -76,17 +76,17 @@ Given the following JSON:
     "wifi": {
         "ssid": "Balena Guest",
         "id": {
-            "$$formula": "super.ssid | slugify"
+            "$$formula": "super.ssid | SLUGIFY"
         }
     }
 }
 ```
 
-* `wifi.id` contains the `$$formula` keyword with the `super.ssid | slugify` value
+* `wifi.id` contains the `$$formula` keyword with the `super.ssid | SLUGIFY` value
 * `super` is evaluated as the `wifi` object
 * `super.ssid` is evaluated as the `wifi.ssid` field
 * `wifi.ssid` is evaluated as the `"Balena Guest"` string
-* `| slugify` applies `slugify` filter to the input value
+* `| SLUGIFY` applies `SLUGIFY` filter to the input value
 * the whole expression is evaluated as the `"balena-guest"` string
   
 The sample JSON evaluates to:
@@ -170,7 +170,7 @@ Example:
 ```json
 {
     "id": {
-        "$$formula": "super.ssid | lower"
+        "$$formula": "super.ssid | LOWER"
     },
     "ssid": "Balena"
 }
@@ -182,13 +182,13 @@ Example:
 
 | Filter | Description |
 | --- | --- |
-| [`date`](#filter-date) | Formats a timestamp as a date (`YYYY-MM-DD`) |
-| [`datetime`](#filter-datetime) | Formats a timestamp as a date time (`YYYY-MM-DDTHH:MM:SSZ`) |
-| [`lower`](#filter-lower) | Lower cases a string |
-| [`slugify`](#filter-slugify) |  Transforms a string into a slug |
-| [`time`](#filter-time) | Formats a timestamp as a time (`HH:MM:SS`) |
-| [`trim`](#filter-trim) | Removes leading and trailing whitespaces |
-| [`upper`](#filter-upper) | Upper cases a string |
+| [`DATE`](#filter-date) | Formats a timestamp as a date (`YYYY-MM-DD`) |
+| [`DATETIME`](#filter-datetime) | Formats a timestamp as a date time (`YYYY-MM-DDTHH:MM:SSZ`) |
+| [`LOWER`](#filter-lower) | Lower cases a string |
+| [`SLUGIFY`](#filter-slugify) |  Transforms a string into a slug |
+| [`TIME`](#filter-time) | Formats a timestamp as a time (`HH:MM:SS`) |
+| [`TRIM`](#filter-trim) | Removes leading and trailing whitespaces |
+| [`UPPER`](#filter-upper) | Upper cases a string |
 
 #### Filter lower
 
@@ -196,7 +196,7 @@ Lower cases a string.
 
 Example:
 
-* `"HaLlO" | lower` is resolved as `"hallo"`
+* `"HaLlO" | LOWER` is resolved as `"hallo"`
 
 #### Filter slugify
 
@@ -205,7 +205,7 @@ hyphens and all other (not letters, numbers, hyphens) characters removed.
 
 Example:
 
-* `"  Balena Ltd! " | slugify` is resolved as `"balena-ltd"`
+* `"  Balena Ltd! " | SLUGIFY` is resolved as `"balena-ltd"`
 
 #### Filter trim
 
@@ -213,7 +213,7 @@ Leading and trailing whitespace characters are removed.
 
 Example:
 
-* `"  aa   " | trim` is resolved as `"aa"`
+* `"  aa   " | TRIM` is resolved as `"aa"`
 
 #### Filter date
 
@@ -224,8 +224,8 @@ Full reference of the format syntax is available in the [chrono documentation].
 
 Example:
 
-* `12345678 | date`
-* `12345678 | date(format="%Y-%m-%d %H:%M")`
+* `12345678 | DATE`
+* `12345678 | DATE(format="%Y-%m-%d %H:%M")`
 
 #### Filter time
 
@@ -236,8 +236,8 @@ Full reference of the format syntax is available in the [chrono documentation].
 
 Example:
 
-* `12345678 | time`
-* `12345678 | time(format="%Y-%m-%d %H:%M")`
+* `12345678 | TIME`
+* `12345678 | TIME(format="%Y-%m-%d %H:%M")`
 
 #### Filter datetime
 
@@ -248,8 +248,8 @@ Full reference of the format syntax is available in the [chrono documentation].
 
 Example:
 
-* `12345678 | datetime`
-* `12345678 | datetime(format="%Y-%m-%d %H:%M")`
+* `12345678 | DATETIME`
+* `12345678 | DATETIME(format="%Y-%m-%d %H:%M")`
 
 #### Filter upper
 
@@ -257,19 +257,19 @@ Upper cases a string.
 
 Example:
 
-* `"HaLlO" | upper` is resolved as `"HALLO"`
+* `"HaLlO" | UPPER` is resolved as `"HALLO"`
 
 ## Functions
 
-Functions can be called without arguments (`uuidv4()`) or with named arguments
-(`now(timestamp=true)`). Positional arguments are not supported.
+Functions can be called without arguments (`UUIDV4()`) or with named arguments
+(`NOW(timestamp=true)`). Positional arguments are not supported.
 
 ### Builtin functions
 
 | Filter | Description |
 | --- | --- |
-| [`uuidv4`](#function-uuidv4) | Generates random UUID v4 |
-| [`now`](#function-now) | Returns the local date time / timestamp |
+| [`UUIDV4`](#function-uuidv4) | Generates random UUID v4 |
+| [`NOW`](#function-now) | Returns the local date time / timestamp |
 
 #### Function uuidv4
 
@@ -277,7 +277,7 @@ Generates random UUID v4 in a hexadecimal, lower case, notation.
 
 Example:
 
-* `uuidv4()`
+* `UUIDV4()`
 
 #### Function now
 

--- a/examples/browser/index.js
+++ b/examples/browser/index.js
@@ -3,7 +3,7 @@ import * as bt from "balena-temen";
 const initialValue = {
     "ssid": "Some Cool SSID Network!",
     "id": {
-        "$$formula": "super.ssid | slugify"
+        "$$formula": "super.ssid | SLUGIFY"
     }
 }
 const stringify = (value) => JSON.stringify(value, null, 2)

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -4,7 +4,7 @@ console.log(
     bt.evaluate({
         "ssid": "Some Cool SSID!",
         "id": {
-            "$$formula": "super.ssid | slugify"
+            "$$formula": "super.ssid | SLUGIFY"
         }
     })
 );

--- a/node/tests/src/builtin/now.test.js
+++ b/node/tests/src/builtin/now.test.js
@@ -1,6 +1,6 @@
 const bt = require('balena-temen');
 
-test('now() generates timestamp', () => {
+test('NOW() generates timestamp', () => {
     const result = {
         timestamp: expect.any(Number)
     };
@@ -8,13 +8,13 @@ test('now() generates timestamp', () => {
     expect(
         bt.evaluate({
             "timestamp": {
-                "$$formula": "now(timestamp=true)"
+                "$$formula": "NOW(timestamp=true)"
             }
         })
     ).toMatchObject(result);
 });
 
-test('now() generates rfc 3339', () => {
+test('NOW() generates rfc 3339', () => {
     const result = {
         date: expect.stringMatching(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\+[0-9]{2}:[0-9]{2}$/)
     };
@@ -22,7 +22,7 @@ test('now() generates rfc 3339', () => {
     expect(
         bt.evaluate({
             "date": {
-                "$$formula": "now()"
+                "$$formula": "NOW()"
             }
         })
     ).toMatchObject(result);

--- a/node/tests/src/builtin/uuidv4.test.js
+++ b/node/tests/src/builtin/uuidv4.test.js
@@ -1,6 +1,6 @@
 const bt = require('balena-temen');
 
-test('uuidv4() generates proper random UUID', () => {
+test('UUIDV4() generates proper random UUID', () => {
     const result = {
         id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
     };
@@ -8,7 +8,7 @@ test('uuidv4() generates proper random UUID', () => {
     expect(
         bt.evaluate({
             "id": {
-                "$$formula": "uuidv4()"
+                "$$formula": "UUIDV4()"
             }
         })
     ).toMatchObject(result);

--- a/node/tests/src/evaluate.test.js
+++ b/node/tests/src/evaluate.test.js
@@ -23,3 +23,18 @@ test('evaluate fn throws', () => {
         }
     ).toThrow();
 });
+
+test('evaluate fn throws with one failing and one succeeding formula', () => {
+    expect(
+        () => {
+            bt.evaluate({
+                "foo": {
+                    "$$formula": "UUIDV4()"
+                },
+                "prop": {
+                    "$$formula": "super.notExistingProperty"
+                }
+            });
+        }
+    ).toThrow();
+});

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,1 @@
 max_width = 120
-
-reorder_imports = false
-reorder_modules = false

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -24,10 +24,7 @@
 //! [grammar]: https://github.com/balena-io-modules/balena-temen/blob/master/src/parser/grammar.pest
 use std::{collections::HashMap, str::FromStr};
 
-use crate::{
-    error::*,
-    parser::parse
-};
+use crate::{error::*, parser::parse};
 
 /// Math operator
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/builtin/filter/lower.rs
+++ b/src/builtin/filter/lower.rs
@@ -21,7 +21,7 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{Context, lower};
+    use super::{lower, Context};
 
     #[test]
     fn result_is_lower_cased() {

--- a/src/builtin/filter/slugify.rs
+++ b/src/builtin/filter/slugify.rs
@@ -34,7 +34,7 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{Context, slugify};
+    use super::{slugify, Context};
 
     #[test]
     fn result_is_trimmed() {

--- a/src/builtin/filter/trim.rs
+++ b/src/builtin/filter/trim.rs
@@ -22,7 +22,7 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{Context, trim};
+    use super::{trim, Context};
 
     #[test]
     fn result_is_trimmed() {

--- a/src/builtin/filter/upper.rs
+++ b/src/builtin/filter/upper.rs
@@ -21,7 +21,7 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{Context, upper};
+    use super::{upper, Context};
 
     #[test]
     fn result_is_upper_cased() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
-use chrono::{DateTime, Utc};
 #[cfg(target_arch = "wasm32")]
 use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 
 #[cfg(not(target_arch = "wasm32"))]
 fn utc_now() -> DateTime<Utc> {

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -25,15 +25,15 @@ impl Default for EngineBuilder {
     /// [`EngineBuilder`]: struct.EngineBuilder.html
     fn default() -> EngineBuilder {
         EngineBuilder::new()
-            .filter("upper", filter::upper)
-            .filter("lower", filter::lower)
-            .filter("time", filter::time)
-            .filter("date", filter::date)
-            .filter("datetime", filter::datetime)
-            .filter("trim", filter::trim)
-            .filter("slugify", filter::slugify)
-            .function("uuidv4", function::uuidv4)
-            .function("now", function::now)
+            .filter("UPPER", filter::upper)
+            .filter("LOWER", filter::lower)
+            .filter("TIME", filter::time)
+            .filter("DATE", filter::date)
+            .filter("DATETIME", filter::datetime)
+            .filter("TRIM", filter::trim)
+            .filter("SLUGIFY", filter::slugify)
+            .function("UUIDV4", function::uuidv4)
+            .function("NOW", function::now)
     }
 }
 
@@ -114,22 +114,22 @@ impl EngineBuilder {
     /// };
     ///
     /// let engine: Engine = EngineBuilder::default()
-    ///     .filter("text", text_filter)
+    ///     .filter("TEXT", text_filter)
     ///     .into();
     /// let mut ctx = Context::default();
     /// let position = Identifier::default();
     /// let data = Value::Null;
     ///
     /// assert_eq!(
-    ///     engine.eval("` abc ` | text", &position, &data, &mut ctx).unwrap(),
+    ///     engine.eval("` abc ` | TEXT", &position, &data, &mut ctx).unwrap(),
     ///     json!(" abc ")
     /// );
     /// assert_eq!(
-    ///     engine.eval("` abc ` | text(trim=true)", &position, &data, &mut ctx).unwrap(),
+    ///     engine.eval("` abc ` | TEXT(trim=true)", &position, &data, &mut ctx).unwrap(),
     ///     json!("abc")
     /// );
     /// assert_eq!(
-    ///     engine.eval("` abc ` | text(trim=true, upper=true)", &position, &data, &mut ctx).unwrap(),
+    ///     engine.eval("` abc ` | TEXT(trim=true, upper=true)", &position, &data, &mut ctx).unwrap(),
     ///     json!("ABC")
     /// );
     /// ```
@@ -186,22 +186,22 @@ impl EngineBuilder {
     /// };
     ///
     /// let engine: Engine = EngineBuilder::default()
-    ///     .function("echo", echo_function)
+    ///     .function("ECHO", echo_function)
     ///     .into();
     /// let mut ctx = Context::default();
     /// let position = Identifier::default();
     /// let data = Value::Null;
     ///
     /// assert_eq!(
-    ///     engine.eval("echo()", &position, &data, &mut ctx).unwrap(),
+    ///     engine.eval("ECHO()", &position, &data, &mut ctx).unwrap(),
     ///     json!("echo")
     /// );
     /// assert_eq!(
-    ///     engine.eval("echo(value=`Hallo`)", &position, &data, &mut ctx).unwrap(),
+    ///     engine.eval("ECHO(value=`Hallo`)", &position, &data, &mut ctx).unwrap(),
     ///     json!("Hallo")
     /// );
     /// assert!(
-    ///     engine.eval("echo(value=1)", &position, &data, &mut ctx).is_err()
+    ///     engine.eval("ECHO(value=1)", &position, &data, &mut ctx).is_err()
     /// );
     /// ```
     ///

--- a/src/engine/helper.rs
+++ b/src/engine/helper.rs
@@ -217,10 +217,10 @@ pub fn eval(data: Value) -> Result<Value> {
 /// let data = json!({
 ///     "ssid": "Zrzka 5G",
 ///     "id": {
-///         "$$formula": "super.ssid | slugify"
+///         "$$formula": "super.ssid | SLUGIFY"
 ///     },
 ///     "upperId": {
-///         "$$formula": "super.id | upper"
+///         "$$formula": "super.id | UPPER"
 ///     }
 /// });
 ///

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -5,13 +5,10 @@ use serde_json::{Number, Value};
 
 use crate::{
     ast::*,
-    builtin::{
-        filter::FilterFn,
-        function::FunctionFn,
-    },
+    builtin::{filter::FilterFn, function::FunctionFn},
     context::Context,
     error::*,
-    utils::{RelativeEq, validate_f64}
+    utils::{validate_f64, RelativeEq},
 };
 
 use self::builder::EngineBuilder;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -92,7 +92,7 @@ impl Engine {
     /// // Filters
     ///
     /// assert_eq!(
-    ///     engine.eval("`Balena is great!` | slugify", &position, &data, &mut ctx).unwrap(),
+    ///     engine.eval("`Balena is great!` | SLUGIFY", &position, &data, &mut ctx).unwrap(),
     ///     json!("balena-is-great")
     /// );
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!     "wifi": {
 //!         "ssid": "Balena Ltd",
 //!         "id": {
-//!             "$$formula": "super.ssid | slugify"
+//!             "$$formula": "super.ssid | SLUGIFY"
 //!         }
 //!     }
 //! });
@@ -85,7 +85,7 @@
 //! );
 //!
 //! assert_eq!(
-//!     engine.eval("`Balena templating engine!` | slugify", &position, &data, &mut ctx).unwrap(),
+//!     engine.eval("`Balena templating engine!` | SLUGIFY", &position, &data, &mut ctx).unwrap(),
 //!     json!("balena-templating-engine")
 //! );
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,19 +193,13 @@
 pub use serde_json::Value;
 
 pub use crate::{
-    builtin::{
-        filter::FilterFn,
-        function::FunctionFn,
-    },
+    builtin::{filter::FilterFn, function::FunctionFn},
     context::Context,
     engine::{
         builder::EngineBuilder,
+        helper::{evaluate, evaluate_with_engine},
         Engine,
-        helper::{
-            evaluate,
-            evaluate_with_engine
-        }
-    }
+    },
 };
 
 #[allow(deprecated)]

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -47,6 +47,14 @@ identifier = @{
     )
 }
 
+function_identifier = @{
+    !reserved ~
+    (
+        "this" | "super" |
+        ( ('A'..'Z' | "_") ~ all_chars{,63} )
+    )
+}
+
 square_brackets = _{
     "[" ~ (integer | string | dotted_square_bracket_identifier) ~ "]"
 }
@@ -122,7 +130,7 @@ logical_expression = { logical_value ~ ((logical_or | logical_and) ~ logical_val
 
 kwarg = { identifier ~ "=" ~ (logical_expression | basic_expression_filter) }
 kwargs = _{ kwarg ~ ("," ~ kwarg )* }
-function_call = { identifier ~ "(" ~ kwargs? ~ ")" }
-filter  = { "|" ~ (function_call | identifier) }
+function_call = { function_identifier ~ "(" ~ kwargs? ~ ")" }
+filter  = { "|" ~ (function_call | function_identifier) }
 
 content = { SOI ~ (logical_expression | basic_expression_filter) ~ EOI }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,16 +3,12 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use pest::{
     iterators::Pair,
-    Parser,
     prec_climber::{Assoc, Operator, PrecClimber},
+    Parser,
 };
 use pest_derive::Parser;
 
-use crate::{
-    ast::*,
-    error::*,
-    utils::validate_f64,
-};
+use crate::{ast::*, error::*, utils::validate_f64};
 
 lazy_static! {
     static ref MATH_CLIMBER: PrecClimber<Rule> = PrecClimber::new(vec![

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -70,7 +70,7 @@ fn parse_function_call(pair: Pair<Rule>) -> Result<FunctionCall> {
 
     for p in pair.into_inner() {
         match p.as_rule() {
-            Rule::identifier => name = Some(p.into_span().as_str().to_string()),
+            Rule::function_identifier => name = Some(p.into_span().as_str().to_string()),
             Rule::kwarg => {
                 let (name, value) = parse_kwarg(p)?;
                 args.insert(name, value);
@@ -93,7 +93,7 @@ fn parse_filter(pair: Pair<Rule>) -> Result<FunctionCall> {
     let mut args = HashMap::new();
     for p in pair.into_inner() {
         match p.as_rule() {
-            Rule::identifier => name = Some(p.into_span().as_str().to_string()),
+            Rule::function_identifier => name = Some(p.into_span().as_str().to_string()),
             Rule::kwarg => {
                 let (name, value) = parse_kwarg(p)?;
                 args.insert(name, value);

--- a/tests/engine/eval/filter.rs
+++ b/tests/engine/eval/filter.rs
@@ -9,24 +9,24 @@ use crate::{test_eval_eq, test_eval_err};
 #[test]
 fn default_filters_are_registered() {
     // All filters have unit tests and it's enough to test if they're called / registered / work
-    test_eval_eq!("1541485381 | time", json!("06:23:01"));
-    test_eval_eq!("1541485381 | date", json!("2018-11-06"));
-    test_eval_eq!("1541485381 | datetime", json!("2018-11-06T06:23:01+00:00"));
-    test_eval_eq!("`A` | lower", json!("a"));
-    test_eval_eq!("`A` | slugify", json!("a"));
-    test_eval_eq!("`A` | trim", json!("A"));
-    test_eval_eq!("`a` | upper", json!("A"));
+    test_eval_eq!("1541485381 | TIME", json!("06:23:01"));
+    test_eval_eq!("1541485381 | DATE", json!("2018-11-06"));
+    test_eval_eq!("1541485381 | DATETIME", json!("2018-11-06T06:23:01+00:00"));
+    test_eval_eq!("`A` | LOWER", json!("a"));
+    test_eval_eq!("`A` | SLUGIFY", json!("a"));
+    test_eval_eq!("`A` | TRIM", json!("A"));
+    test_eval_eq!("`a` | UPPER", json!("A"));
 }
 
 #[test]
 fn filter_chain() {
-    test_eval_eq!("`a` | lower | upper", json!("A"));
-    test_eval_eq!("`A` | lower | upper", json!("A"));
+    test_eval_eq!("`a` | LOWER | UPPER", json!("A"));
+    test_eval_eq!("`A` | LOWER | UPPER", json!("A"));
 }
 
 #[test]
 fn fail_on_unknown_filter() {
-    test_eval_err!("1 | filterdoesnotexistoratleastitshouldnot");
+    test_eval_err!("1 | FILTERDOESNOTEXISTORATLEASTITSHOULDNOT");
 }
 
 #[test]
@@ -39,8 +39,8 @@ fn custom_filter() {
         }
     };
 
-    let engine: Engine = EngineBuilder::default().filter("atob", cf).into();
+    let engine: Engine = EngineBuilder::default().filter("ATOB", cf).into();
 
-    test_eval_eq!(engine, "`abc` | atob", json!("bbc"));
-    test_eval_err!(engine, "true | atob");
+    test_eval_eq!(engine, "`abc` | ATOB", json!("bbc"));
+    test_eval_err!(engine, "true | ATOB");
 }

--- a/tests/engine/eval/filter.rs
+++ b/tests/engine/eval/filter.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde_json::json;
 
-use balena_temen::{Context, Engine, EngineBuilder, error::*, Value};
+use balena_temen::{error::*, Context, Engine, EngineBuilder, Value};
 
 use crate::{test_eval_eq, test_eval_err};
 

--- a/tests/engine/eval/function.rs
+++ b/tests/engine/eval/function.rs
@@ -9,13 +9,13 @@ use crate::{test_eval_eq, test_eval_err, test_eval_ok};
 #[test]
 fn default_functions_are_registered() {
     // All functions have unit tests and it's enough to test if they're called / registered / work
-    test_eval_ok!("uuidv4()");
-    test_eval_ok!("now()");
+    test_eval_ok!("UUIDV4()");
+    test_eval_ok!("NOW()");
 }
 
 #[test]
 fn fail_on_unknown_function() {
-    test_eval_err!("fndoesnotexistoratleastitshouldnot()");
+    test_eval_err!("FNDOESNOTEXISTORATLEASTITSHOULDNOT()");
 }
 
 #[test]
@@ -28,8 +28,8 @@ fn custom_function() {
         }
     };
 
-    let engine: Engine = EngineBuilder::default().function("echo", cf).into();
+    let engine: Engine = EngineBuilder::default().function("ECHO", cf).into();
 
-    test_eval_eq!(engine, "echo()", json!("no-value-passed"));
-    test_eval_eq!(engine, "echo(value=`Zrzka`)", json!("Zrzka"));
+    test_eval_eq!(engine, "ECHO()", json!("no-value-passed"));
+    test_eval_eq!(engine, "ECHO(value=`Zrzka`)", json!("Zrzka"));
 }

--- a/tests/engine/eval/logical.rs
+++ b/tests/engine/eval/logical.rs
@@ -19,10 +19,10 @@ fn equal() {
 
 #[test]
 fn equal_with_filter() {
-    test_eval_eq!("`abc` | upper == 'ABC'", json!(true));
-    test_eval_eq!("`ABC` | lower == 'abc'", json!(true));
-    test_eval_eq!("`ABC` == 'abc' | upper", json!(true));
-    test_eval_eq!("`abc` == 'ABC' | lower", json!(true));
+    test_eval_eq!("`abc` | UPPER == 'ABC'", json!(true));
+    test_eval_eq!("`ABC` | LOWER == 'abc'", json!(true));
+    test_eval_eq!("`ABC` == 'abc' | UPPER", json!(true));
+    test_eval_eq!("`abc` == 'ABC' | LOWER", json!(true));
 }
 
 #[test]

--- a/tests/engine/eval_as_bool/filter.rs
+++ b/tests/engine/eval_as_bool/filter.rs
@@ -3,5 +3,5 @@ use crate::test_eval_as_bool_err;
 #[test]
 fn fail_on_invalid_output_type() {
     // Evaluates to String
-    test_eval_as_bool_err!("`true` | lower");
+    test_eval_as_bool_err!("`true` | LOWER");
 }

--- a/tests/engine/eval_as_bool/function.rs
+++ b/tests/engine/eval_as_bool/function.rs
@@ -3,5 +3,5 @@ use crate::test_eval_as_bool_err;
 #[test]
 fn fail_on_invalid_output_type() {
     // Evaluates to String
-    test_eval_as_bool_err!("uuidv4()");
+    test_eval_as_bool_err!("UUIDV4()");
 }

--- a/tests/engine/helper.rs
+++ b/tests/engine/helper.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use balena_temen::{Context, Engine, EngineBuilder, evaluate, evaluate_with_engine};
+use balena_temen::{evaluate, evaluate_with_engine, Context, Engine, EngineBuilder};
 
 #[test]
 fn primitive_types_pass_through() {

--- a/tests/engine/helper.rs
+++ b/tests/engine/helper.rs
@@ -29,7 +29,7 @@ fn array() {
         "a",
         "b",
         {
-            "$$formula": "`C` | lower"
+            "$$formula": "`C` | LOWER"
         },
         "d"
     ]);

--- a/tests/engine/regressions.rs
+++ b/tests/engine/regressions.rs
@@ -1,0 +1,18 @@
+use serde_json::json;
+
+use balena_temen::{evaluate, evaluate_with_engine, Context, Engine, EngineBuilder};
+
+#[test]
+fn one_formula_fail_second_formula_success() {
+    // Lucian & Alex calculation project
+    let data = json!({
+        "foo": {
+            "$$formula": "UUIDV4()"
+        },
+        "prop": {
+            "$$formula": "super.notExistingProperty"
+        }
+    });
+
+    assert!(evaluate(data).is_err());
+}

--- a/tests/parser/filter.rs
+++ b/tests/parser/filter.rs
@@ -7,10 +7,10 @@ fn single_filter() {
     let exp = Expression::new_with_filters(
         ExpressionValue::String("Abc".to_string()),
         vec![
-            FunctionCall::new("slugify".to_string(), HashMap::default())
+            FunctionCall::new("SLUGIFY".to_string(), HashMap::default())
         ],
     );
-    test_parse_eq!("'Abc' | slugify", exp);
+    test_parse_eq!("'Abc' | SLUGIFY", exp);
 }
 
 #[test]
@@ -18,9 +18,9 @@ fn chained_filter() {
     let exp = Expression::new_with_filters(
         ExpressionValue::String("Abc".to_string()),
         vec![
-            FunctionCall::new("slugify".to_string(), HashMap::default()),
-            FunctionCall::new("rustify".to_string(), HashMap::default()),
+            FunctionCall::new("SLUGIFY".to_string(), HashMap::default()),
+            FunctionCall::new("RUSTIFY".to_string(), HashMap::default()),
         ],
     );
-    test_parse_eq!("'Abc' | slugify | rustify", exp);
+    test_parse_eq!("'Abc' | SLUGIFY | RUSTIFY", exp);
 }

--- a/tests/parser/function.rs
+++ b/tests/parser/function.rs
@@ -5,8 +5,8 @@ use crate::{fn_args_map, test_parse_eq};
 #[test]
 fn without_arguments() {
     test_parse_eq!(
-        "uuid()",
-        Expression::new(ExpressionValue::FunctionCall(FunctionCall::new("uuid", fn_args_map!())))
+        "UUID()",
+        Expression::new(ExpressionValue::FunctionCall(FunctionCall::new("UUID", fn_args_map!())))
     );
 }
 
@@ -18,7 +18,7 @@ fn with_arguments() {
     };
 
     test_parse_eq!(
-        "uuid(v=4, dummy=`abc`)",
-        Expression::new(ExpressionValue::FunctionCall(FunctionCall::new("uuid", args)))
+        "UUID(v=4, dummy=`abc`)",
+        Expression::new(ExpressionValue::FunctionCall(FunctionCall::new("UUID", args)))
     );
 }


### PR DESCRIPTION
Breaking changes:

* all functions and filters are UPPER cased
  * `uuidv4()` -> `UUIDV4()`
  * `super.ssid | slugify` -> `super.ssid | SLUGIFY`

Fixed:

* Multiple formulas evaluation. It was supported, [check this test](https://github.com/balena-io-modules/balena-temen/blob/calculations-fixes/tests/engine/helper.rs#L42-L53), but there was a really stupid  bug in the logic, which wasn't catched by any test.