### PR TITLE
Fix stack overflow

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -380,21 +380,7 @@ impl Engine {
         data: &Value,
         context: &mut Context,
     ) -> Result<Number> {
-        if expression.filters.is_empty() {
-            // We can directly evaluate the value as a number, because
-            // we have no filters
-            return self.eval_value_as_number(&expression.value, position, data, context);
-        }
-
-        // In case of filters, just evaluate the expression as a generic one
-        // and check if the result is a Number
-        let value = &*self.eval_expression(expression, position, data, context)?;
-        match value {
-            Value::Number(num) => Ok(num.clone()),
-            _ => Err(unable_to_evaluate_as_a_number_error()
-                .context("expression", format!("{:?}", expression))
-                .context("reason", "result is not a number")),
-        }
+        self.eval_value_as_number(&expression.value, position, data, context)
     }
 
     fn eval_ternary_expression<'a>(

--- a/tests/engine/mod.rs
+++ b/tests/engine/mod.rs
@@ -1,3 +1,4 @@
 mod eval;
 mod eval_as_bool;
 mod helper;
+mod regressions;

--- a/tests/engine/regressions.rs
+++ b/tests/engine/regressions.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use balena_temen::{evaluate, evaluate_with_engine, Context, Engine, EngineBuilder};
+use balena_temen::evaluate;
 
 #[test]
 fn one_formula_fail_second_formula_success() {
@@ -11,6 +11,22 @@ fn one_formula_fail_second_formula_success() {
         },
         "prop": {
             "$$formula": "super.notExistingProperty"
+        }
+    });
+
+    assert!(evaluate(data).is_err());
+}
+
+#[test]
+fn fuzzer_invalid_overflow() {
+    // Found by Cyryl's fuzzer
+    // This isn't about parser input, but evaluation engine recursive
+    // loop, which was caused by the eval_as_number function. Called by
+    // eval_expression and eval_as_number called eval_expression again.
+    let data = json!({
+        " ssid": "S(ssidool SSID Network!",
+        "id": {
+            "$$formula": "sup/r.ssid | SLUGIFY"
         }
     });
 


### PR DESCRIPTION
That was quick. Never ending loop in the evaluation engine. Flawed logic. It will basically crash with any math expression followed by filter (like `x * y | FILTER`).